### PR TITLE
Improve handling of search for YTDL executables

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -147,6 +147,12 @@ namespace AudioLink
         [MenuItem(userDefinedYTDLPathMenu, priority = 1)]
         private static void SelectYtdlInstall()
         {
+            if (Menu.GetChecked(userDefinedYTDLPathMenu))
+            {
+                EditorPrefs.SetString(userDefinedYTDLPathKey, string.Empty);
+                return;
+            }
+
             string ytdlPath = EditorPrefs.GetString(userDefinedYTDLPathKey, "");
             string tpath = ytdlPath.Substring(0, ytdlPath.LastIndexOf("/", StringComparison.Ordinal) + 1);
             string path = EditorUtility.OpenFilePanel("Select YTDL Location", tpath, "");
@@ -182,6 +188,7 @@ namespace AudioLink
                     Debug.Log($"[AudioLink:ytdlp] Custom YTDL location found: {customPath}");
                     _ytdlpPath = customPath;
                     _ytdlpFound = true;
+                    return;
                 }
 
                 Debug.LogWarning($"[AudioLink:ytdlp] Custom YTDL location detected but does not exist: {customPath}");
@@ -343,11 +350,7 @@ namespace AudioLink
                     EditorGUI.BeginChangeCheck();
                     _ytdlpPlayer.ytdlpURL = EditorGUILayout.TextField(_ytdlpPlayer.ytdlpURL);
                     if (EditorGUI.EndChangeCheck())
-                    {
                         EditorUtility.SetDirty(_ytdlpPlayer);
-                    }
-
-                    ;
                     _ytdlpPlayer.resolution = (ytdlpPlayer.Resolution)EditorGUILayout.EnumPopup(_ytdlpPlayer.resolution, GUILayout.Width(65));
                 }
 

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -19,13 +19,11 @@ namespace AudioLink
         public string ytdlpURL = "https://www.youtube.com/watch?v=SFTcZ1GXOCQ";
         ytdlpRequest _currentRequest = null;
 
-        [SerializeField]
-        public bool showVideoPreviewInComponent = false;
+        [SerializeField] public bool showVideoPreviewInComponent = false;
 
         public VideoPlayer videoPlayer = null;
 
-        [SerializeField]
-        public Resolution resolution = Resolution._720p;
+        [SerializeField] public Resolution resolution = Resolution._720p;
 
         public enum Resolution
         {
@@ -153,7 +151,6 @@ namespace AudioLink
             string tpath = ytdlPath.Substring(0, ytdlPath.LastIndexOf("/", StringComparison.Ordinal) + 1);
             string path = EditorUtility.OpenFilePanel("Select YTDL Location", tpath, "");
             EditorPrefs.SetString(userDefinedYTDLPathKey, path ?? string.Empty);
-
         }
 
         [MenuItem(userDefinedYTDLPathMenu, true, priority = 1)]
@@ -238,10 +235,7 @@ namespace AudioLink
             proc.StartInfo.FileName = _ytdlpPath;
             proc.StartInfo.Arguments = $"--no-check-certificate --no-cache-dir --rm-cache-dir -f \"mp4[height<=?{resolution}]/best[height<=?{resolution}]\" --get-url \"{url}\"";
 
-            proc.Exited += (sender, args) =>
-            {
-                proc.Dispose();
-            };
+            proc.Exited += (sender, args) => { proc.Dispose(); };
 
             proc.OutputDataReceived += (sender, args) =>
             {
@@ -332,7 +326,11 @@ namespace AudioLink
 
         public override void OnInspectorGUI()
         {
+#if UNITY_EDITOR_LINUX
+            bool available = false;
+#else
             bool available = ytdlpURLResolver.IsytdlpAvailable();
+#endif
             bool hasVideoPlayer = _ytdlpPlayer.videoPlayer != null;
             float playbackTime = hasVideoPlayer ? _ytdlpPlayer.GetPlaybackTime() : 0;
             double videoLength = hasVideoPlayer ? _ytdlpPlayer.videoPlayer.length : 0;
@@ -347,7 +345,9 @@ namespace AudioLink
                     if (EditorGUI.EndChangeCheck())
                     {
                         EditorUtility.SetDirty(_ytdlpPlayer);
-                    };
+                    }
+
+                    ;
                     _ytdlpPlayer.resolution = (ytdlpPlayer.Resolution)EditorGUILayout.EnumPopup(_ytdlpPlayer.resolution, GUILayout.Width(65));
                 }
 
@@ -462,6 +462,5 @@ namespace AudioLink
             }
         }
     }
-
 }
 #endif

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -23,7 +23,7 @@ namespace AudioLink
 
         public VideoPlayer videoPlayer = null;
 
-        [SerializeField] public Resolution resolution = Resolution._2160p;
+        [SerializeField] public Resolution resolution = Resolution._720p;
 
         public enum Resolution
         {
@@ -59,16 +59,12 @@ namespace AudioLink
             if (videoPlayer == null)
                 return;
 
-            videoPlayer.prepareCompleted -= MediaReady;
-            videoPlayer.prepareCompleted += MediaReady;
             videoPlayer.url = resolved;
-            videoPlayer.Prepare();
-        }
-
-        private void MediaReady(VideoPlayer player)
-        {
-            SetPlaybackTime(player, 0.0f);
-            if (player.length > 0) player.Play();
+            SetPlaybackTime(0.0f);
+            if (videoPlayer.length > 0)
+            {
+                videoPlayer.Play();
+            }
         }
 
         public float GetPlaybackTime()
@@ -79,10 +75,10 @@ namespace AudioLink
                 return 0;
         }
 
-        public void SetPlaybackTime(VideoPlayer player, float time)
+        public void SetPlaybackTime(float time)
         {
-            if (player != null && player.length > 0 && player.canSetTime)
-                player.time = player.length * Mathf.Clamp(time, 0.0f, 1.0f);
+            if (videoPlayer != null && videoPlayer.length > 0 && videoPlayer.canSetTime)
+                videoPlayer.time = videoPlayer.length * Mathf.Clamp(time, 0.0f, 1.0f);
         }
 
         public string FormattedTimestamp(double seconds, double maxSeconds = 0)
@@ -383,7 +379,7 @@ namespace AudioLink
                         EditorGUI.BeginChangeCheck();
                         playbackTime = GUILayout.HorizontalSlider(playbackTime, 0, 1);
                         if (EditorGUI.EndChangeCheck())
-                            _ytdlpPlayer.SetPlaybackTime(_ytdlpPlayer.videoPlayer, playbackTime);
+                            _ytdlpPlayer.SetPlaybackTime(playbackTime);
 
                         // Timestamp input
                         EditorGUI.BeginChangeCheck();
@@ -400,7 +396,7 @@ namespace AudioLink
                             if (TimeSpan.TryParse($"00:{seekTimestamp}", out inputTimestamp))
                             {
                                 playbackTime = (float)(inputTimestamp.TotalSeconds / videoLength);
-                                _ytdlpPlayer.SetPlaybackTime(_ytdlpPlayer.videoPlayer, playbackTime);
+                                _ytdlpPlayer.SetPlaybackTime(playbackTime);
                             }
                         }
                     }

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -23,7 +23,7 @@ namespace AudioLink
 
         public VideoPlayer videoPlayer = null;
 
-        [SerializeField] public Resolution resolution = Resolution._720p;
+        [SerializeField] public Resolution resolution = Resolution._2160p;
 
         public enum Resolution
         {
@@ -59,12 +59,16 @@ namespace AudioLink
             if (videoPlayer == null)
                 return;
 
+            videoPlayer.prepareCompleted -= MediaReady;
+            videoPlayer.prepareCompleted += MediaReady;
             videoPlayer.url = resolved;
-            SetPlaybackTime(0.0f);
-            if (videoPlayer.length > 0)
-            {
-                videoPlayer.Play();
-            }
+            videoPlayer.Prepare();
+        }
+
+        private void MediaReady(VideoPlayer player)
+        {
+            SetPlaybackTime(player, 0.0f);
+            if (player.length > 0) player.Play();
         }
 
         public float GetPlaybackTime()
@@ -75,10 +79,10 @@ namespace AudioLink
                 return 0;
         }
 
-        public void SetPlaybackTime(float time)
+        public void SetPlaybackTime(VideoPlayer player, float time)
         {
-            if (videoPlayer != null && videoPlayer.length > 0 && videoPlayer.canSetTime)
-                videoPlayer.time = videoPlayer.length * Mathf.Clamp(time, 0.0f, 1.0f);
+            if (player != null && player.length > 0 && player.canSetTime)
+                player.time = player.length * Mathf.Clamp(time, 0.0f, 1.0f);
         }
 
         public string FormattedTimestamp(double seconds, double maxSeconds = 0)
@@ -379,7 +383,7 @@ namespace AudioLink
                         EditorGUI.BeginChangeCheck();
                         playbackTime = GUILayout.HorizontalSlider(playbackTime, 0, 1);
                         if (EditorGUI.EndChangeCheck())
-                            _ytdlpPlayer.SetPlaybackTime(playbackTime);
+                            _ytdlpPlayer.SetPlaybackTime(_ytdlpPlayer.videoPlayer, playbackTime);
 
                         // Timestamp input
                         EditorGUI.BeginChangeCheck();
@@ -396,7 +400,7 @@ namespace AudioLink
                             if (TimeSpan.TryParse($"00:{seekTimestamp}", out inputTimestamp))
                             {
                                 playbackTime = (float)(inputTimestamp.TotalSeconds / videoLength);
-                                _ytdlpPlayer.SetPlaybackTime(playbackTime);
+                                _ytdlpPlayer.SetPlaybackTime(_ytdlpPlayer.videoPlayer, playbackTime);
                             }
                         }
                     }

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -144,6 +144,8 @@ namespace AudioLink
         private const string userDefinedYTDLPathKey = "YTDL-PATH-CUSTOM";
         private const string userDefinedYTDLPathMenu = "Tools/AudioLink/Select Custom YTDL Location";
 
+        // don't enable custom YTDL location menu item if project is VRCWorld type. It's only used for avatar testing, so it's useless otherwise.
+#if !UDONSHARP
         [MenuItem(userDefinedYTDLPathMenu, priority = 1)]
         private static void SelectYtdlInstall()
         {
@@ -165,6 +167,7 @@ namespace AudioLink
             Menu.SetChecked(userDefinedYTDLPathMenu, EditorPrefs.GetString(userDefinedYTDLPathKey, string.Empty) != string.Empty);
             return true;
         }
+#endif
 
         public static bool IsytdlpAvailable()
         {


### PR DESCRIPTION
- Improve path search logic to include some standard YTDL (not just yt-dlp) executable names.  
- Add menu option for specifying a precise custom executable location under Tools -> AudioLink -> Select - Custom YTDL Location.  
- Move _localytdlpPath use to windows only as it's an exe specific path.  
- Update LocateExecutable to support intaking a list of possible known ytdl executable names to improve search reliability.  
- Update LocateExecutable to support PATH quirks with certain MSeries Macbooks.  