### PR TITLE
Redundant Media Start Fix

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/AudioLinkAvatar.prefab
+++ b/Packages/com.llealloo.audiolink/Runtime/AudioLinkAvatar.prefab
@@ -84,7 +84,7 @@ MonoBehaviour:
   ytdlpURL: https://www.youtube.com/watch?v=SFTcZ1GXOCQ
   showVideoPreviewInComponent: 0
   videoPlayer: {fileID: 5208934818770322006}
-  resolution: 720
+  resolution: 2160
 --- !u!1 &8800328339556915021
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/com.llealloo.audiolink/Runtime/AudioLinkAvatar.prefab
+++ b/Packages/com.llealloo.audiolink/Runtime/AudioLinkAvatar.prefab
@@ -84,7 +84,7 @@ MonoBehaviour:
   ytdlpURL: https://www.youtube.com/watch?v=SFTcZ1GXOCQ
   showVideoPreviewInComponent: 0
   videoPlayer: {fileID: 5208934818770322006}
-  resolution: 2160
+  resolution: 720
 --- !u!1 &8800328339556915021
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -25,7 +25,7 @@ namespace AudioLink
         public VideoPlayer videoPlayer = null;
 
         [SerializeField]
-        public Resolution resolution = Resolution._720p;
+        public Resolution resolution = Resolution._2160p;
 
         public enum Resolution
         {
@@ -61,12 +61,16 @@ namespace AudioLink
             if (videoPlayer == null)
                 return;
 
+            videoPlayer.prepareCompleted -= MediaReady;
+            videoPlayer.prepareCompleted += MediaReady;
             videoPlayer.url = resolved;
-            SetPlaybackTime(0.0f);
-            if (videoPlayer.length > 0)
-            {
-                videoPlayer.Play();
-            }
+            videoPlayer.Prepare();
+        }
+
+        private void MediaReady(VideoPlayer player)
+        {
+            SetPlaybackTime(player, 0.0f);
+            if (player.length > 0) player.Play();
         }
 
         public float GetPlaybackTime()
@@ -77,10 +81,10 @@ namespace AudioLink
                 return 0;
         }
 
-        public void SetPlaybackTime(float time)
+        public void SetPlaybackTime(VideoPlayer player, float time)
         {
-            if (videoPlayer != null && videoPlayer.length > 0 && videoPlayer.canSetTime)
-                videoPlayer.time = videoPlayer.length * Mathf.Clamp(time, 0.0f, 1.0f);
+            if (player != null && player.length > 0 && player.canSetTime)
+                player.time = player.length * Mathf.Clamp(time, 0.0f, 1.0f);
         }
 
         public string FormattedTimestamp(double seconds, double maxSeconds = 0)
@@ -327,7 +331,7 @@ namespace AudioLink
                         EditorGUI.BeginChangeCheck();
                         playbackTime = GUILayout.HorizontalSlider(playbackTime, 0, 1);
                         if (EditorGUI.EndChangeCheck())
-                            _ytdlpPlayer.SetPlaybackTime(playbackTime);
+                            _ytdlpPlayer.SetPlaybackTime(_ytdlpPlayer.videoPlayer, playbackTime);
 
                         // Timestamp input
                         EditorGUI.BeginChangeCheck();
@@ -344,7 +348,7 @@ namespace AudioLink
                             if (TimeSpan.TryParse($"00:{seekTimestamp}", out inputTimestamp))
                             {
                                 playbackTime = (float)(inputTimestamp.TotalSeconds / videoLength);
-                                _ytdlpPlayer.SetPlaybackTime(playbackTime);
+                                _ytdlpPlayer.SetPlaybackTime(_ytdlpPlayer.videoPlayer, playbackTime);
                             }
                         }
                     }
@@ -352,8 +356,8 @@ namespace AudioLink
                     // Media Controls
                     using (new EditorGUILayout.HorizontalScope())
                     {
-                        bool isPlaying = hasVideoPlayer ? _ytdlpPlayer.videoPlayer.isPlaying : false;
-                        bool isPaused = hasVideoPlayer ? _ytdlpPlayer.videoPlayer.isPaused : false;
+                        bool isPlaying = hasVideoPlayer && _ytdlpPlayer.videoPlayer.isPlaying;
+                        bool isPaused = hasVideoPlayer && _ytdlpPlayer.videoPlayer.isPaused;
                         bool isStopped = !isPlaying && !isPaused;
 
                         bool play = GUILayout.Toggle(isPlaying, new GUIContent(" Play", EditorGUIUtility.IconContent("d_PlayButton On").image), "Button") != isPlaying;

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -25,7 +25,7 @@ namespace AudioLink
         public VideoPlayer videoPlayer = null;
 
         [SerializeField]
-        public Resolution resolution = Resolution._2160p;
+        public Resolution resolution = Resolution._720p;
 
         public enum Resolution
         {
@@ -265,7 +265,10 @@ namespace AudioLink
     [CustomEditor(typeof(ytdlpPlayer))]
     public class ytdlpPlayerEditor : UnityEditor.Editor
     {
-        ytdlpPlayer _ytdlpPlayer;
+        private ytdlpPlayer _ytdlpPlayer;
+
+        private SerializedProperty ytdlpURL;
+        private SerializedProperty resolution;
 
         void OnEnable()
         {
@@ -273,6 +276,9 @@ namespace AudioLink
             // If video player is on the same gameobject, assign it automatically
             if (_ytdlpPlayer.gameObject.GetComponent<VideoPlayer>() != null)
                 _ytdlpPlayer.videoPlayer = _ytdlpPlayer.gameObject.GetComponent<VideoPlayer>();
+
+            ytdlpURL = serializedObject.FindProperty(nameof(_ytdlpPlayer.ytdlpURL));
+            resolution = serializedObject.FindProperty(nameof(_ytdlpPlayer.resolution));
         }
 
         public override bool RequiresConstantRepaint()
@@ -285,6 +291,7 @@ namespace AudioLink
 
         public override void OnInspectorGUI()
         {
+            serializedObject.Update();
 #if UNITY_EDITOR_LINUX
             bool available = false;
 #else
@@ -300,13 +307,8 @@ namespace AudioLink
                 using (new EditorGUILayout.HorizontalScope())
                 {
                     EditorGUILayout.LabelField(new GUIContent(" Video URL", EditorGUIUtility.IconContent("CloudConnect").image), GUILayout.Width(100));
-                    EditorGUI.BeginChangeCheck();
-                    _ytdlpPlayer.ytdlpURL = EditorGUILayout.TextField(_ytdlpPlayer.ytdlpURL);
-                    if (EditorGUI.EndChangeCheck())
-                    {
-                        EditorUtility.SetDirty(_ytdlpPlayer);
-                    };
-                    _ytdlpPlayer.resolution = (ytdlpPlayer.Resolution)EditorGUILayout.EnumPopup(_ytdlpPlayer.resolution, GUILayout.Width(65));
+                    EditorGUILayout.PropertyField(ytdlpURL, GUIContent.none);
+                    EditorGUILayout.PropertyField(resolution, GUIContent.none, GUILayout.Width(65));
                 }
 
                 using (new EditorGUI.DisabledScope(!hasVideoPlayer || !EditorApplication.isPlaying))
@@ -418,6 +420,8 @@ namespace AudioLink
                 EditorGUILayout.HelpBox("Failed to locate yt-dlp executable. To fix this, install yt-dlp and make sure the executable is on your PATH. Once this is done, enter play mode to retry.", MessageType.Warning);
 #endif
             }
+
+            serializedObject.ApplyModifiedProperties();
         }
     }
 


### PR DESCRIPTION
Fix the video player restarting the media ~3 seconds in by offloading the video player Play action to the `prepareCompleted` event.

Swap to using SerializedProperty for the url and resolution fields.
Simplify a couple ternary conditions.