### PR TITLE
Change default Ytdlp URL to something more tolerate

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/AudioLinkAvatar.prefab
+++ b/Packages/com.llealloo.audiolink/Runtime/AudioLinkAvatar.prefab
@@ -29,7 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8800328339556915023}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -85,6 +85,16 @@ MonoBehaviour:
   showVideoPreviewInComponent: 0
   videoPlayer: {fileID: 5208934818770322006}
   resolution: 720
+  enableGlobalVideoTexture: 0
+  globalTextureName: _Udon_VideoTex
+  textureTransformMode: 1
+  texturePixelOrigin: {x: 0, y: 0}
+  texturePixelSize: {x: 0, y: 0}
+  textureTiling: {x: 1, y: 1}
+  textureOffset: {x: 0, y: 0}
+  forceStandbyTexture: 0
+  showStandbyIfPaused: 1
+  standbyTexture: {fileID: 0}
 --- !u!1 &8800328339556915021
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/com.llealloo.audiolink/Runtime/AudioLinkAvatar.prefab
+++ b/Packages/com.llealloo.audiolink/Runtime/AudioLinkAvatar.prefab
@@ -29,7 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 8800328339556915023}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -81,20 +81,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: af9b9b5c52a71184bb2fad4c01f0bc4d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ytdlpURL: https://www.youtube.com/watch?v=SFTcZ1GXOCQ
+  ytdlpURL: https://www.youtube.com/watch?v=dZPcLi2-5dE
   showVideoPreviewInComponent: 0
   videoPlayer: {fileID: 5208934818770322006}
   resolution: 720
-  enableGlobalVideoTexture: 0
-  globalTextureName: _Udon_VideoTex
-  textureTransformMode: 1
-  texturePixelOrigin: {x: 0, y: 0}
-  texturePixelSize: {x: 0, y: 0}
-  textureTiling: {x: 1, y: 1}
-  textureOffset: {x: 0, y: 0}
-  forceStandbyTexture: 0
-  showStandbyIfPaused: 1
-  standbyTexture: {fileID: 0}
 --- !u!1 &8800328339556915021
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -24,7 +24,7 @@ namespace AudioLink
             ByPixels
         }
 
-        public string ytdlpURL = "https://www.youtube.com/watch?v=SFTcZ1GXOCQ";
+        public string ytdlpURL = "https://www.youtube.com/watch?v=dZPcLi2-5dE";
         ytdlpRequest _currentRequest = null;
 
         public bool showVideoPreviewInComponent = false;


### PR DESCRIPTION
I'm probably going to be very salty about this, but I think the default music URL is just really hard to listen to. Especially if I have to listen to it when helping other people out in a sharescreen when teaching people how to test AudioLink.

So, I've changed it. **It's the same exact video that is played in llealloo's AudioLink V2 World found [here](https://www.youtube.com/watch?v=dZPcLi2-5dE).** Many of the songs in this link are copyright-free and hit on all 4 bands, so this shouldn't be a problem.

Thank you for your consideration.