### PR TITLE
Try and Catch on Unlink

### DIFF
--- a/AudioLinkWebProject/Assets/Plugins/WebGL/WebALPeer.jslib
+++ b/AudioLinkWebProject/Assets/Plugins/WebGL/WebALPeer.jslib
@@ -108,7 +108,7 @@ var AnalyserLink = {
                 return 0;
 
             } catch (e) {
-                throw e;
+                delete window["_WebALPeerAnalysers"][name];
             }
 
         }
@@ -165,5 +165,4 @@ var AnalyserLink = {
     }
 };
 
-//autoAddDeps(AnalyserLink, "$analysers");
 mergeInto(LibraryManager.library, AnalyserLink);


### PR DESCRIPTION
Attempts to recover from a invalid `UnlinkAnalyser()` call