### PR TITLE
Make use of FindObjectsByType consistent. 

### DIFF
--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkEditor.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkEditor.cs
@@ -2,9 +2,8 @@
 using System.Reflection;
 
 #if UDONSHARP
-using UdonSharp;
 using UdonSharpEditor;
-using BehaviourType = UdonSharpBehaviour;
+using BehaviourType = UdonSharp.UdonSharpBehaviour;
 #else
 using BehaviourType = MonoBehaviour;
 #endif
@@ -87,11 +86,11 @@ namespace AudioLink.Editor
 
         public static void LinkAll(AudioLink target)
         {
-            BehaviourType[] allBehaviours = FindObjectsByType<BehaviourType>(
-#if UNITY_6000_0_OR_NEWER
-                FindObjectsInactive.Include, FindObjectsSortMode.InstanceID
-#endif            
-            );
+#if UNITY_2021_3_OR_NEWER
+            BehaviourType[] allBehaviours = FindObjectsByType<BehaviourType>(FindObjectsInactive.Include, FindObjectsSortMode.InstanceID);
+#else
+            BehaviourType[] allBehaviours = FindObjectsOfType<BehaviourType>(true);
+#endif
 
             // this handles all reasonable cases of referencing audiolink
             // (it doesn't handle referencing it multiple times in one monobehaviour, or referencing it as it's Base type)
@@ -110,6 +109,7 @@ namespace AudioLink.Editor
                         }
                     }
                 }
+
                 if (fieldInfo != null && fieldInfo.FieldType == typeof(AudioLink))
                 {
                     fieldInfo.SetValue(behaviour, target);

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkEditor.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkEditor.cs
@@ -86,12 +86,13 @@ namespace AudioLink.Editor
 
         public static void LinkAll(AudioLink target)
         {
+            BehaviourType[] allBehaviours = FindObjectsByType<BehaviourType>(
 #if UNITY_2021_3_OR_NEWER
-            BehaviourType[] allBehaviours = FindObjectsByType<BehaviourType>(FindObjectsInactive.Include, FindObjectsSortMode.InstanceID);
+                FindObjectsInactive.Include, FindObjectsSortMode.InstanceID
 #else
-            BehaviourType[] allBehaviours = FindObjectsOfType<BehaviourType>(true);
+                true
 #endif
-
+            );
             // this handles all reasonable cases of referencing audiolink
             // (it doesn't handle referencing it multiple times in one monobehaviour, or referencing it as it's Base type)
             foreach (BehaviourType behaviour in allBehaviours)


### PR DESCRIPTION
Anything beyond 2021.3 supports the ByType API.
Is additional cleanup from #324 changes.