### PR TITLE
Add URP support, minor shader cleanup

### DIFF
--- a/Packages/com.llealloo.audiolink/Editor/AudioLinkPipelineDetector.cs
+++ b/Packages/com.llealloo.audiolink/Editor/AudioLinkPipelineDetector.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using UnityEditor;
+using System.Linq;
+using UnityEngine.Rendering;
+
+[InitializeOnLoad]
+public static class AudioLinkPipelineDetector
+{
+    static AudioLinkPipelineDetector()
+    {
+        DetectPackages();
+#if UNITY_2021_1_OR_NEWER
+        RenderPipelineManager.activeRenderPipelineTypeChanged -= DetectPackages;
+        RenderPipelineManager.activeRenderPipelineTypeChanged += DetectPackages;
+#endif
+    }
+
+    // [MenuItem("Tools/VRSL/Check Pipeline")]
+    private static void DetectPackages()
+    {
+        // Check for URP
+        bool hasURP = DoesPackageExist("com.unity.render-pipelines.universal");
+        if (hasURP) Shader.EnableKeyword("UNIVERSAL_RENDER_PIPELINE");
+        else Shader.DisableKeyword("UNIVERSAL_RENDER_PIPELINE");
+
+        // Check for other packages as needed
+        // bool hasHDRP = DoesPackageExist("com.unity.render-pipelines.");
+        bool hasHDRP = DoesPackageExist("com.unity.render-pipelines.high-definition");
+        if (hasHDRP) Shader.EnableKeyword("HIGH_DEFINITION_RENDER_PIPELINE");
+        else Shader.DisableKeyword("HIGH_DEFINITION_RENDER_PIPELINE");
+    }
+
+    private static bool DoesPackageExist(string packageName)
+    {
+        // For Unity 2019.3+
+#if UNITY_2019_3_OR_NEWER
+        var listRequest = UnityEditor.PackageManager.Client.List(true);
+        while (!listRequest.IsCompleted) { }
+
+        bool found;
+        if (listRequest.Status == UnityEditor.PackageManager.StatusCode.Success)
+        {
+            return listRequest.Result.Any(package => package.name == packageName);
+        }
+#endif
+
+        // Fallback method for earlier Unity versions: check for package directory
+        string packagePath = $"Packages/{packageName}";
+        return System.IO.Directory.Exists(packagePath);
+    }
+}

--- a/Packages/com.llealloo.audiolink/Editor/AudioLinkPipelineDetector.cs.meta
+++ b/Packages/com.llealloo.audiolink/Editor/AudioLinkPipelineDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79eedd29b45b48c4a8cb3a0858b991a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.llealloo.audiolink/Editor/AudioLinkStandardInspector.cs
+++ b/Packages/com.llealloo.audiolink/Editor/AudioLinkStandardInspector.cs
@@ -1,0 +1,94 @@
+using UnityEngine;
+using UnityEditor;
+using System;
+using System.Reflection;
+using UnityEngine.Rendering;
+
+namespace VRSL.Shaders
+{
+// Create a custom shader GUI that switches between Standard and URP Lit inspector
+    public class AudioLinkStandardInspector : ShaderGUI
+    {
+        // References to keep track of our reflected editor instances
+        private ShaderGUI urpLitGUI = null;
+        private ShaderGUI standardGUI = null;
+        private bool guiCheckComplete;
+
+        private void EnsureShaderGUIAvailable()
+        {
+            if (guiCheckComplete) return;
+            guiCheckComplete = true;
+            // Check if the project is using URP
+            bool isURP = GraphicsSettings.currentRenderPipeline != null &&
+                         GraphicsSettings.currentRenderPipeline.GetType().ToString().Contains("Universal");
+
+            if (isURP)
+            {
+                if (urpLitGUI != null) return;
+                // Try to create URP Lit GUI instance via reflection
+                try
+                {
+                    // Get the URP Editor assembly
+                    Assembly urpEditorAssembly = null;
+                    Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+                    foreach (var assembly in assemblies)
+                    {
+                        if (assembly.GetName().Name == "Unity.RenderPipelines.Universal.Editor")
+                        {
+                            urpEditorAssembly = assembly;
+                            break;
+                        }
+                    }
+
+                    if (urpEditorAssembly != null)
+                    {
+                        // Get the LitShaderGUI type
+                        Type litGUIType = urpEditorAssembly.GetType("UnityEditor.Rendering.Universal.ShaderGUI.LitShader");
+                        if (litGUIType != null) urpLitGUI = Activator.CreateInstance(litGUIType) as ShaderGUI;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Failed to create URP Lit GUI: " + e.Message);
+                }
+            }
+            else
+            {
+                try
+                {
+                    // Get the Standard ShaderGUI type from UnityEditor assembly
+                    Assembly editorAssembly = typeof(EditorGUILayout).Assembly;
+                    Type standardGUIType = editorAssembly.GetType("UnityEditor.StandardShaderGUI");
+                    if (standardGUIType != null) standardGUI = Activator.CreateInstance(standardGUIType) as ShaderGUI;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Failed to create Standard GUI: " + e.Message);
+                }
+            }
+        }
+
+        // material changed check
+        public override void ValidateMaterial(Material material)
+        {
+            EnsureShaderGUIAvailable();
+            urpLitGUI?.ValidateMaterial(material);
+            standardGUI?.ValidateMaterial(material);
+        }
+
+        // shader change check
+        public override void AssignNewShaderToMaterial(Material material, Shader oldShader, Shader newShader)
+        {
+            EnsureShaderGUIAvailable();
+            urpLitGUI?.AssignNewShaderToMaterial(material, oldShader, newShader);
+            standardGUI?.AssignNewShaderToMaterial(material, oldShader, newShader);
+        }
+
+        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] properties)
+        {
+            EnsureShaderGUIAvailable();
+            urpLitGUI?.OnGUI(materialEditor, properties);
+            standardGUI?.OnGUI(materialEditor, properties);
+        }
+    }
+}

--- a/Packages/com.llealloo.audiolink/Editor/AudioLinkStandardInspector.cs.meta
+++ b/Packages/com.llealloo.audiolink/Editor/AudioLinkStandardInspector.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 97912c1b2054d0c4f9fd8330e039d6d6
+timeCreated: 1747362724

--- a/Packages/com.llealloo.audiolink/Runtime/Materials/mat_AudioLinkMiniPlayerScreen.mat
+++ b/Packages/com.llealloo.audiolink/Runtime/Materials/mat_AudioLinkMiniPlayerScreen.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: mat_AudioLinkMiniPlayerScreen
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: f00b5b7bf3b4b204691945f5eba97a16, type: 3}
   m_ShaderKeywords: APPLY_GAMMA _ _EMISSION
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0

--- a/Packages/com.llealloo.audiolink/Runtime/Materials/mat_ControllerBody.mat
+++ b/Packages/com.llealloo.audiolink/Runtime/Materials/mat_ControllerBody.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: mat_ControllerBody
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: f00b5b7bf3b4b204691945f5eba97a16, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1

--- a/Packages/com.llealloo.audiolink/Runtime/Materials/mat_ControllerHandle.mat
+++ b/Packages/com.llealloo.audiolink/Runtime/Materials/mat_ControllerHandle.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: mat_ControllerHandle
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: f00b5b7bf3b4b204691945f5eba97a16, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Packages/com.llealloo.audiolink/Runtime/Materials/mat_SpectrumCoords.mat
+++ b/Packages/com.llealloo.audiolink/Runtime/Materials/mat_SpectrumCoords.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: mat_SpectrumCoords
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: f00b5b7bf3b4b204691945f5eba97a16, type: 3}
   m_ShaderKeywords: _ALPHAPREMULTIPLY_ON _EMISSION
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0

--- a/Packages/com.llealloo.audiolink/Runtime/Materials/mat_UdonAudioLink.mat
+++ b/Packages/com.llealloo.audiolink/Runtime/Materials/mat_UdonAudioLink.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: mat_UdonAudioLink
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: f00b5b7bf3b4b204691945f5eba97a16, type: 3}
   m_ShaderKeywords: _ALPHATEST_ON _EMISSION
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurface.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurface.shader
@@ -1,8 +1,8 @@
-// Upgrade NOTE: upgraded instancing buffer 'AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha' to new syntax.
+// Upgrade NOTE: upgraded instancing buffer 'AudioLinkSurfaceAudioReactiveSurface' to new syntax.
 
 // Made with Amplify Shader Editor
 // Available at the Unity Asset Store - http://u3d.as/y3X
-Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
+Shader "AudioLink/Amplify/AudioReactiveSurface"
 {
 	Properties
 	{
@@ -42,12 +42,12 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 	SubShader
 	{
 
-		Tags { "RenderType"="Transparent" "Queue"="Transparent" "DisableBatching"="False" }
+		Tags { "RenderType"="Opaque" "Queue"="Geometry" "DisableBatching"="False" }
 	LOD 0
 
 		Cull Back
 		AlphaToMask Off
-		ZWrite Off
+		ZWrite On
 		ZTest LEqual
 		ColorMask RGBA
 
@@ -157,13 +157,16 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 		}
 		ENDCG
 
+
 		Pass
 		{
-			Blend SrcAlpha OneMinusSrcAlpha
+
+			Name "ForwardBase"
+			Tags { "LightMode"="ForwardBase" }
+
+			Blend One Zero
 
 			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
 			#define ASE_NEEDS_FRAG_SHADOWCOORDS
 			#pragma multi_compile_instancing
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
@@ -266,26 +269,26 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			uniform sampler2D _EmissionMap;
 			uniform float _Metallic;
 			uniform float _Smoothness;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
 				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Band_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
 
 			float3 HSVToRGB( float3 c )
@@ -304,7 +307,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float e = 1.0e-10;
 				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
 			}
-			inline float AudioLinkLerp3_g8( int Band, float Delay )
+			inline float AudioLinkLerp3_g6( int Band, float Delay )
 			{
 				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
 			}
@@ -506,27 +509,26 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				#endif
 
 				float2 texCoord6 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2DNode4 * _Color ).rgb );
+				float3 hsvTorgb32 = RGBToHSV( ( tex2D( _MainTex, texCoord6 ) * _Color ).rgb );
 				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
 				float hueShift33 = _AudioHueShift_Instance;
 				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g8 = (int)_Band_Instance;
+				int Band3_g6 = (int)_Band_Instance;
 				float2 texCoord50 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g10 = texCoord50;
-				float temp_output_5_0_g10 = ( break6_g10.x - 0.5 );
+				float2 break6_g4 = texCoord50;
+				float temp_output_5_0_g4 = ( break6_g4.x - 0.5 );
 				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g10 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g10 = cos( temp_output_2_0_g10 );
-				float temp_output_8_0_g10 = sin( temp_output_2_0_g10 );
-				float temp_output_20_0_g10 = ( 1.0 / ( abs( temp_output_3_0_g10 ) + abs( temp_output_8_0_g10 ) ) );
-				float temp_output_7_0_g10 = ( break6_g10.y - 0.5 );
-				float2 appendResult16_g10 = (float2(( ( ( temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) + ( temp_output_7_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) - ( temp_output_5_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 )));
+				float temp_output_2_0_g4 = radians( _PulseRotation_Instance );
+				float temp_output_3_0_g4 = cos( temp_output_2_0_g4 );
+				float temp_output_8_0_g4 = sin( temp_output_2_0_g4 );
+				float temp_output_20_0_g4 = ( 1.0 / ( abs( temp_output_3_0_g4 ) + abs( temp_output_8_0_g4 ) ) );
+				float temp_output_7_0_g4 = ( break6_g4.y - 0.5 );
+				float2 appendResult16_g4 = (float2(( ( ( temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) + ( temp_output_7_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) - ( temp_output_5_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 )));
 				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
 				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g8 = ( ( (_Delay_Instance + (( appendResult16_g10.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8( Band3_g8 , Delay3_g8 );
-				float temp_output_96_0 = localAudioLinkLerp3_g8;
+				float Delay3_g6 = ( ( (_Delay_Instance + (( appendResult16_g4.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
+				float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6( Band3_g6 , Delay3_g6 );
+				float temp_output_96_0 = localAudioLinkLerp3_g6;
 				float amplitude36 = temp_output_96_0;
 				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
 
@@ -540,8 +542,6 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
 				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
 
-				float alpha98 = tex2DNode4.a;
-
 				o.Albedo = hsvTorgb39;
 				o.Normal = ( UnpackNormal( tex2D( _BumpMap, uv_BumpMap ) ) * _BumpScale );
 				o.Emission = ( hsvTorgb45 * _Emission_Instance );
@@ -552,7 +552,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				#endif
 				o.Smoothness = _Smoothness;
 				o.Occlusion = 1;
-				o.Alpha = alpha98;
+				o.Alpha = 1;
 				float AlphaClipThreshold = 0.5;
 				float AlphaClipThresholdShadow = 0.5;
 				float3 BakedGI = 0;
@@ -692,17 +692,16 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			ENDCG
 		}
 
+
 		Pass
 		{
 
 			Name "ForwardAdd"
 			Tags { "LightMode"="ForwardAdd" }
 			ZWrite Off
-			Blend SrcAlpha One
+			Blend One One
 
 			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
 			#define ASE_NEEDS_FRAG_SHADOWCOORDS
 			#pragma multi_compile_instancing
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
@@ -799,26 +798,26 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			uniform sampler2D _EmissionMap;
 			uniform float _Metallic;
 			uniform float _Smoothness;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
 				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Band_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
 
 			float3 HSVToRGB( float3 c )
@@ -837,7 +836,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float e = 1.0e-10;
 				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
 			}
-			inline float AudioLinkLerp3_g8( int Band, float Delay )
+			inline float AudioLinkLerp3_g6( int Band, float Delay )
 			{
 				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
 			}
@@ -1020,27 +1019,26 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 
 
 				float2 texCoord6 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2DNode4 * _Color ).rgb );
+				float3 hsvTorgb32 = RGBToHSV( ( tex2D( _MainTex, texCoord6 ) * _Color ).rgb );
 				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
 				float hueShift33 = _AudioHueShift_Instance;
 				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g8 = (int)_Band_Instance;
+				int Band3_g6 = (int)_Band_Instance;
 				float2 texCoord50 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g10 = texCoord50;
-				float temp_output_5_0_g10 = ( break6_g10.x - 0.5 );
+				float2 break6_g4 = texCoord50;
+				float temp_output_5_0_g4 = ( break6_g4.x - 0.5 );
 				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g10 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g10 = cos( temp_output_2_0_g10 );
-				float temp_output_8_0_g10 = sin( temp_output_2_0_g10 );
-				float temp_output_20_0_g10 = ( 1.0 / ( abs( temp_output_3_0_g10 ) + abs( temp_output_8_0_g10 ) ) );
-				float temp_output_7_0_g10 = ( break6_g10.y - 0.5 );
-				float2 appendResult16_g10 = (float2(( ( ( temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) + ( temp_output_7_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) - ( temp_output_5_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 )));
+				float temp_output_2_0_g4 = radians( _PulseRotation_Instance );
+				float temp_output_3_0_g4 = cos( temp_output_2_0_g4 );
+				float temp_output_8_0_g4 = sin( temp_output_2_0_g4 );
+				float temp_output_20_0_g4 = ( 1.0 / ( abs( temp_output_3_0_g4 ) + abs( temp_output_8_0_g4 ) ) );
+				float temp_output_7_0_g4 = ( break6_g4.y - 0.5 );
+				float2 appendResult16_g4 = (float2(( ( ( temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) + ( temp_output_7_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) - ( temp_output_5_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 )));
 				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
 				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g8 = ( ( (_Delay_Instance + (( appendResult16_g10.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8( Band3_g8 , Delay3_g8 );
-				float temp_output_96_0 = localAudioLinkLerp3_g8;
+				float Delay3_g6 = ( ( (_Delay_Instance + (( appendResult16_g4.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
+				float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6( Band3_g6 , Delay3_g6 );
+				float temp_output_96_0 = localAudioLinkLerp3_g6;
 				float amplitude36 = temp_output_96_0;
 				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
 
@@ -1054,8 +1052,6 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
 				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
 
-				float alpha98 = tex2DNode4.a;
-
 				o.Albedo = hsvTorgb39;
 				o.Normal = ( UnpackNormal( tex2D( _BumpMap, uv_BumpMap ) ) * _BumpScale );
 				o.Emission = ( hsvTorgb45 * _Emission_Instance );
@@ -1066,7 +1062,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				#endif
 				o.Smoothness = _Smoothness;
 				o.Occlusion = 1;
-				o.Alpha = alpha98;
+				o.Alpha = 1;
 				float AlphaClipThreshold = 0.5;
 				float3 Transmission = 1;
 				float3 Translucency = 1;
@@ -1168,8 +1164,6 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			AlphaToMask Off
 
 			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
 			#define ASE_NEEDS_FRAG_SHADOWCOORDS
 			#pragma multi_compile_instancing
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
@@ -1256,26 +1250,26 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			uniform sampler2D _EmissionMap;
 			uniform float _Metallic;
 			uniform float _Smoothness;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
 				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Band_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
 
 			float3 HSVToRGB( float3 c )
@@ -1294,7 +1288,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float e = 1.0e-10;
 				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
 			}
-			inline float AudioLinkLerp3_g8( int Band, float Delay )
+			inline float AudioLinkLerp3_g6( int Band, float Delay )
 			{
 				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
 			}
@@ -1478,27 +1472,26 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				half atten = 1;
 
 				float2 texCoord6 = IN.ase_texcoord8.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2DNode4 * _Color ).rgb );
+				float3 hsvTorgb32 = RGBToHSV( ( tex2D( _MainTex, texCoord6 ) * _Color ).rgb );
 				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
 				float hueShift33 = _AudioHueShift_Instance;
 				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g8 = (int)_Band_Instance;
+				int Band3_g6 = (int)_Band_Instance;
 				float2 texCoord50 = IN.ase_texcoord8.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g10 = texCoord50;
-				float temp_output_5_0_g10 = ( break6_g10.x - 0.5 );
+				float2 break6_g4 = texCoord50;
+				float temp_output_5_0_g4 = ( break6_g4.x - 0.5 );
 				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g10 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g10 = cos( temp_output_2_0_g10 );
-				float temp_output_8_0_g10 = sin( temp_output_2_0_g10 );
-				float temp_output_20_0_g10 = ( 1.0 / ( abs( temp_output_3_0_g10 ) + abs( temp_output_8_0_g10 ) ) );
-				float temp_output_7_0_g10 = ( break6_g10.y - 0.5 );
-				float2 appendResult16_g10 = (float2(( ( ( temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) + ( temp_output_7_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) - ( temp_output_5_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 )));
+				float temp_output_2_0_g4 = radians( _PulseRotation_Instance );
+				float temp_output_3_0_g4 = cos( temp_output_2_0_g4 );
+				float temp_output_8_0_g4 = sin( temp_output_2_0_g4 );
+				float temp_output_20_0_g4 = ( 1.0 / ( abs( temp_output_3_0_g4 ) + abs( temp_output_8_0_g4 ) ) );
+				float temp_output_7_0_g4 = ( break6_g4.y - 0.5 );
+				float2 appendResult16_g4 = (float2(( ( ( temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) + ( temp_output_7_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) - ( temp_output_5_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 )));
 				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
 				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g8 = ( ( (_Delay_Instance + (( appendResult16_g10.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8( Band3_g8 , Delay3_g8 );
-				float temp_output_96_0 = localAudioLinkLerp3_g8;
+				float Delay3_g6 = ( ( (_Delay_Instance + (( appendResult16_g4.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
+				float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6( Band3_g6 , Delay3_g6 );
+				float temp_output_96_0 = localAudioLinkLerp3_g6;
 				float amplitude36 = temp_output_96_0;
 				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
 
@@ -1512,8 +1505,6 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
 				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
 
-				float alpha98 = tex2DNode4.a;
-
 				o.Albedo = hsvTorgb39;
 				o.Normal = ( UnpackNormal( tex2D( _BumpMap, uv_BumpMap ) ) * _BumpScale );
 				o.Emission = ( hsvTorgb45 * _Emission_Instance );
@@ -1524,7 +1515,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				#endif
 				o.Smoothness = _Smoothness;
 				o.Occlusion = 1;
-				o.Alpha = alpha98;
+				o.Alpha = 1;
 				float AlphaClipThreshold = 0.5;
 				float3 BakedGI = 0;
 
@@ -1624,8 +1615,6 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			Cull Off
 
 			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
 			#define ASE_NEEDS_FRAG_SHADOWCOORDS
 			#pragma multi_compile_instancing
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
@@ -1693,24 +1682,24 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			uniform sampler2D _MainTex;
 			uniform float4 _Color;
 			uniform sampler2D _EmissionMap;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Band_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
 				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
 
 			float3 HSVToRGB( float3 c )
@@ -1729,7 +1718,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float e = 1.0e-10;
 				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
 			}
-			inline float AudioLinkLerp3_g8( int Band, float Delay )
+			inline float AudioLinkLerp3_g6( int Band, float Delay )
 			{
 				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
 			}
@@ -1886,27 +1875,26 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				#endif
 
 				float2 texCoord6 = IN.ase_texcoord3.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2DNode4 * _Color ).rgb );
+				float3 hsvTorgb32 = RGBToHSV( ( tex2D( _MainTex, texCoord6 ) * _Color ).rgb );
 				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
 				float hueShift33 = _AudioHueShift_Instance;
 				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g8 = (int)_Band_Instance;
+				int Band3_g6 = (int)_Band_Instance;
 				float2 texCoord50 = IN.ase_texcoord3.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g10 = texCoord50;
-				float temp_output_5_0_g10 = ( break6_g10.x - 0.5 );
+				float2 break6_g4 = texCoord50;
+				float temp_output_5_0_g4 = ( break6_g4.x - 0.5 );
 				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g10 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g10 = cos( temp_output_2_0_g10 );
-				float temp_output_8_0_g10 = sin( temp_output_2_0_g10 );
-				float temp_output_20_0_g10 = ( 1.0 / ( abs( temp_output_3_0_g10 ) + abs( temp_output_8_0_g10 ) ) );
-				float temp_output_7_0_g10 = ( break6_g10.y - 0.5 );
-				float2 appendResult16_g10 = (float2(( ( ( temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) + ( temp_output_7_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) - ( temp_output_5_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 )));
+				float temp_output_2_0_g4 = radians( _PulseRotation_Instance );
+				float temp_output_3_0_g4 = cos( temp_output_2_0_g4 );
+				float temp_output_8_0_g4 = sin( temp_output_2_0_g4 );
+				float temp_output_20_0_g4 = ( 1.0 / ( abs( temp_output_3_0_g4 ) + abs( temp_output_8_0_g4 ) ) );
+				float temp_output_7_0_g4 = ( break6_g4.y - 0.5 );
+				float2 appendResult16_g4 = (float2(( ( ( temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) + ( temp_output_7_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) - ( temp_output_5_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 )));
 				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
 				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g8 = ( ( (_Delay_Instance + (( appendResult16_g10.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8( Band3_g8 , Delay3_g8 );
-				float temp_output_96_0 = localAudioLinkLerp3_g8;
+				float Delay3_g6 = ( ( (_Delay_Instance + (( appendResult16_g4.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
+				float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6( Band3_g6 , Delay3_g6 );
+				float temp_output_96_0 = localAudioLinkLerp3_g6;
 				float amplitude36 = temp_output_96_0;
 				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
 
@@ -1917,12 +1905,10 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
 				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
 
-				float alpha98 = tex2DNode4.a;
-
 				o.Albedo = hsvTorgb39;
 				o.Normal = fixed3( 0, 0, 1 );
 				o.Emission = ( hsvTorgb45 * _Emission_Instance );
-				o.Alpha = alpha98;
+				o.Alpha = 1;
 				float AlphaClipThreshold = 0.5;
 
 				#ifdef _ALPHATEST_ON
@@ -1957,8 +1943,6 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			AlphaToMask Off
 
 			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
 			#define ASE_NEEDS_FRAG_SHADOWCOORDS
 			#pragma multi_compile_instancing
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
@@ -1998,13 +1982,13 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float3 normal : NORMAL;
 				float4 texcoord1 : TEXCOORD1;
 				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
+
 				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct v2f {
 				V2F_SHADOW_CASTER;
-				float4 ase_texcoord2 : TEXCOORD2;
+
 				UNITY_VERTEX_INPUT_INSTANCE_ID
 				UNITY_VERTEX_OUTPUT_STEREO
 			};
@@ -2020,9 +2004,8 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float _TessEdgeLength;
 				float _TessMaxDisp;
 			#endif
-			uniform sampler2D _MainTex;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
 
 
@@ -2033,10 +2016,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				UNITY_TRANSFER_INSTANCE_ID(v,o);
 				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
-				o.ase_texcoord2.xy = v.ase_texcoord.xy;
 
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord2.zw = 0;
 				#ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
 				#else
@@ -2064,7 +2044,6 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float3 normal : NORMAL;
 				float4 texcoord1 : TEXCOORD1;
 				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
 
 				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
@@ -2085,7 +2064,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				o.normal = v.normal;
 				o.texcoord1 = v.texcoord1;
 				o.texcoord2 = v.texcoord2;
-				o.ase_texcoord = v.ase_texcoord;
+
 				return o;
 			}
 
@@ -2127,7 +2106,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				o.normal = patch[0].normal * bary.x + patch[1].normal * bary.y + patch[2].normal * bary.z;
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
-				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
+
 				#if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
@@ -2166,13 +2145,10 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
 				#endif
 
-				float2 texCoord6 = IN.ase_texcoord2.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float alpha98 = tex2DNode4.a;
 
 				o.Normal = fixed3( 0, 0, 1 );
 				o.Occlusion = 1;
-				o.Alpha = alpha98;
+				o.Alpha = 1;
 				float AlphaClipThreshold = 0.5;
 				float AlphaClipThresholdShadow = 0.5;
 
@@ -2206,148 +2182,103 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			}
 			ENDCG
 		}
-        Pass
-        {
-            Name "DepthOnly"
-            Tags{"LightMode" = "DepthOnly"}
-
-            ZWrite On
-            ColorMask 0
-            Cull Back
-            Blend SrcAlpha OneMinusSrcAlpha
-
-            CGPROGRAM
-            #pragma vertex vert
-            #pragma fragment frag
-            #pragma multi_compile_instancing
-            #include "UnityCG.cginc"
-            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
-
-            struct appdata
-            {
-                float4 vertex : POSITION;
-                float4 texcoord : TEXCOORD0;
-                UNITY_VERTEX_INPUT_INSTANCE_ID
-            };
-
-            struct v2f
-            {
-                float4 vertex : SV_POSITION;
-                float2 texcoord : TEXCOORD0;
-                UNITY_VERTEX_INPUT_INSTANCE_ID
-                UNITY_VERTEX_OUTPUT_STEREO
-            };
-
-            sampler2D _MainTex;
-
-            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-
-            v2f vert(appdata v)
-            {
-                v2f o;
-                UNITY_SETUP_INSTANCE_ID(v);
-                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                UNITY_TRANSFER_INSTANCE_ID(v, o);
-                o.vertex = UnityObjectToClipPos(v.vertex);
-                o.texcoord = v.texcoord.xy;
-                return o;
-            }
-
-            float4 frag(v2f i) : SV_TARGET
-            {
-                UNITY_SETUP_INSTANCE_ID(i);
-                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
-
-                float4 tex2DNode4 = tex2D(_MainTex, i.texcoord);
-                float alpha = tex2DNode4.a;
-
-                #if defined(_ALPHATEST_ON)
-                    clip(alpha - 0.5);
-                #endif
-
-                return 0;
-            }
-            ENDCG
-        }
-
-        // DepthNormals pass
-        Pass
-        {
-            Name "DepthNormals"
-            Tags{"LightMode" = "DepthNormals"}
-
-            ZWrite On
-            Cull Back
-            Blend SrcAlpha OneMinusSrcAlpha
-
-            CGPROGRAM
-            #pragma vertex vert
-            #pragma fragment frag
-            #pragma multi_compile_instancing
-            #include "UnityCG.cginc"
-            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
-
-            struct appdata
-            {
-                float4 vertex : POSITION;
-                float3 normal : NORMAL;
-                float4 tangent : TANGENT;
-                float4 texcoord : TEXCOORD0;
-                UNITY_VERTEX_INPUT_INSTANCE_ID
-            };
-
-            struct v2f
-            {
-                float4 vertex : SV_POSITION;
-                float2 texcoord : TEXCOORD0;
-                float3 normal : TEXCOORD1;
-                UNITY_VERTEX_INPUT_INSTANCE_ID
-                UNITY_VERTEX_OUTPUT_STEREO
-            };
-
-            sampler2D _MainTex;
-            sampler2D _BumpMap;
-            float _BumpScale;
-
-            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-            #define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-
-            v2f vert(appdata v)
-            {
-                v2f o;
-                UNITY_SETUP_INSTANCE_ID(v);
-                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                UNITY_TRANSFER_INSTANCE_ID(v, o);
-                o.vertex = UnityObjectToClipPos(v.vertex);
-                o.texcoord = v.texcoord.xy;
-                o.normal = UnityObjectToWorldNormal(v.normal);
-                return o;
-            }
-
-            float4 frag(v2f i) : SV_TARGET
-            {
-                UNITY_SETUP_INSTANCE_ID(i);
-                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
-
-                float4 tex2DNode4 = tex2D(_MainTex, i.texcoord);
-                float alpha = tex2DNode4.a;
-
-                #if defined(_ALPHATEST_ON)
-                    clip(alpha - 0.5);
-                #endif
-
-                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
-                float2 uv_BumpMap = i.texcoord * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
-                float3 normalMap = UnpackNormal(tex2D(_BumpMap, uv_BumpMap));
-                float3 normal = normalize(normalMap * float3(_BumpScale, _BumpScale, 1.0));
-
-                return float4(normal * 0.5 + 0.5, 1);
-            }
-            ENDCG
-        }
 
 	}
+	CustomEditor "ASEMaterialInspector"
+
+
 }
+/*ASEBEGIN
+Version=18908
+3114.4;81.6;2712;1462;2899.47;881.0705;1.515001;True;False
+Node;AmplifyShaderEditor.RangedFloatNode;31;-1390.638,-584.899;Inherit;False;InstancedProperty;_AudioHueShift;Audio Hue Shift;12;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;2;-955,-202.5;Inherit;False;Property;_Color;Color;1;0;Create;True;0;0;0;False;0;False;0.4980392,0.4980392,0.4980392,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.GetLocalVarNode;34;-366.2949,-141.8591;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SamplerNode;9;-936,-2;Inherit;True;Property;_BumpMap;Normal Map;4;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;bump;Auto;True;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;5;-597,-280;Inherit;False;2;2;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;1;COLOR;0
+Node;AmplifyShaderEditor.RangedFloatNode;12;261.2,1021.201;Inherit;False;Property;_Smoothness;Smoothness;3;0;Create;True;0;0;0;False;0;False;0.5;0.5;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.TextureCoordinatesNode;50;-2385.262,732.5444;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.FunctionNode;69;-1917.486,737.521;Inherit;False;RotateUVFill;-1;;4;459952d587cbfe742a7e7f4a8a0a4169;0;2;1;FLOAT2;0,0;False;2;FLOAT;0;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.RegisterLocalVarNode;33;-1046.295,-583.8591;Inherit;False;hueShift;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;10;-812,202;Inherit;False;Property;_BumpScale;Normal Scale;5;0;Create;False;0;0;0;False;0;False;1;1;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.BreakToComponentsNode;78;-1616.565,796.2052;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.FunctionNode;96;-961.7287,821.9091;Inherit;False;4BandAmplitudeLerp;-1;;6;3cf4b6e83381a9a4f84f8cf857bc3af5;0;2;2;INT;0;False;4;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleAddOpNode;44;70.29944,482.272;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.GetLocalVarNode;37;-372.7727,-36.59692;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;38;-152.7727,-73.59692;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;47;534.9175,735.4701;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.FunctionNode;93;-1410.24,873.1649;Inherit;False;BandPulse;-1;;7;c478702160369ce4480fa2fb6d734ffa;0;3;1;FLOAT;0;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RadiansOpNode;51;-2083.566,860.3765;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RGBToHSVNode;32;-372.2949,-372.8591;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.TextureCoordinatesNode;6;-1357,-367;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;43;-91.17834,730.5342;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;98;-1137.932,882.2094;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;128;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RegisterLocalVarNode;36;-599.8431,921.3793;Inherit;False;amplitude;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.HSVToRGBNode;39;191.2273,-167.5969;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.SimpleAddOpNode;35;8.705078,-321.8591;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SamplerNode;14;-989.8879,298.6613;Inherit;True;Property;_EmissionMap;Emission Map;6;0;Create;True;0;0;0;False;0;False;-1;None;None;True;0;False;gray;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.HSVToRGBNode;45;252.8217,636.5342;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.GetLocalVarNode;42;-304.7005,662.272;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;11;-502,92;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;15;-528.8879,636.6613;Inherit;False;3;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.RangedFloatNode;49;-2381.913,871.5845;Inherit;False;InstancedProperty;_PulseRotation;Pulse Rotation;13;0;Create;True;0;0;0;False;0;False;0;0;0;360;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;57;-1752.023,925.6572;Inherit;False;InstancedProperty;_Pulse;Pulse;11;1;[Header];Create;True;1;Pulse Across UVs;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;18;-1751.102,1027.495;Inherit;False;InstancedProperty;_Delay;Delay;10;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;17;-1434.696,642.8046;Inherit;False;InstancedProperty;_Band;Band;9;2;[Header];[IntRange];Create;True;1;Audio Section;0;0;False;0;False;0;0;0;3;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;46;255.5175,800.3702;Inherit;False;InstancedProperty;_Emission;Emission Scale;8;0;Create;False;0;0;0;False;0;False;1;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;13;258.2,923.202;Inherit;False;Property;_Metallic;Metallic;2;0;Create;True;0;0;0;False;0;False;0;0.5;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RGBToHSVNode;40;-310.7005,431.272;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.GetLocalVarNode;41;-311.1783,767.5342;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SamplerNode;4;-1039,-416;Inherit;True;Property;_MainTex;Albedo;0;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;white;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ColorNode;3;-935.8119,580.942;Inherit;False;InstancedProperty;_EmissionColor;Emission Color;7;1;[HDR];Create;True;0;0;0;False;0;False;0,0,0,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;85;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Deferred;0;3;Deferred;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Deferred;True;2;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;86;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Meta;0;4;Meta;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Meta;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;82;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ExtraPrePass;0;0;ExtraPrePass;6;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;True;True;0;False;-1;0;False;-1;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;87;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ShadowCaster;0;5;ShadowCaster;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;False;-1;True;3;False;-1;False;True;1;LightMode=ShadowCaster;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;84;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ForwardAdd;0;2;ForwardAdd;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;4;1;False;-1;1;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;True;1;LightMode=ForwardAdd;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;83;824,664;Float;False;True;-1;2;ASEMaterialInspector;0;10;AudioLink/Surface/AudioReactiveSurface;f0be08cf82190c945883605df227bec5;True;ForwardBase;0;1;ForwardBase;18;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;40;Workflow,InvertActionOnDeselection;1;Surface;0;  Blend;0;  Refraction Model;0;  Dither Shadows;1;Two Sided;1;Deferred Pass;1;Transmission;0;  Transmission Shadow;0.5,False,-1;Translucency;0;  Translucency Strength;1,False,-1;  Normal Distortion;0.5,False,-1;  Scattering;2,False,-1;  Direct;0.9,False,-1;  Ambient;0.1,False,-1;  Shadow;0.5,False,-1;Cast Shadows;1;  Use Shadow Threshold;0;Receive Shadows;1;GPU Instancing;1;LOD CrossFade;1;Built-in Fog;1;Ambient Light;1;Meta Pass;1;Add Pass;1;Override Baked GI;0;Extra Pre Pass;0;Tessellation;0;  Phong;0;  Strength;0.5,False,-1;  Type;0;  Tess;16,False,-1;  Min;10,False,-1;  Max;25,False,-1;  Edge Length;16,False,-1;  Max Displacement;25,False,-1;Fwd Specular Highlights Toggle;0;Fwd Reflections Toggle;0;Disable Batching;0;Vertex Position,InvertActionOnDeselection;1;0;6;False;True;True;True;True;True;False;;False;0
+WireConnection;5;0;4;0
+WireConnection;5;1;2;0
+WireConnection;69;1;50;0
+WireConnection;69;2;51;0
+WireConnection;33;0;31;0
+WireConnection;78;0;69;0
+WireConnection;96;2;17;0
+WireConnection;96;4;98;0
+WireConnection;44;0;40;1
+WireConnection;44;1;43;0
+WireConnection;38;0;34;0
+WireConnection;38;1;37;0
+WireConnection;47;0;45;0
+WireConnection;47;1;46;0
+WireConnection;93;1;78;0
+WireConnection;93;2;57;0
+WireConnection;93;3;18;0
+WireConnection;51;0;49;0
+WireConnection;32;0;5;0
+WireConnection;43;0;42;0
+WireConnection;43;1;41;0
+WireConnection;98;0;93;0
+WireConnection;36;0;96;0
+WireConnection;39;0;35;0
+WireConnection;39;1;32;2
+WireConnection;39;2;32;3
+WireConnection;35;0;32;1
+WireConnection;35;1;38;0
+WireConnection;45;0;44;0
+WireConnection;45;1;40;2
+WireConnection;45;2;40;3
+WireConnection;11;0;9;0
+WireConnection;11;1;10;0
+WireConnection;15;0;14;0
+WireConnection;15;1;3;0
+WireConnection;15;2;96;0
+WireConnection;40;0;15;0
+WireConnection;4;1;6;0
+WireConnection;83;0;39;0
+WireConnection;83;1;11;0
+WireConnection;83;2;47;0
+WireConnection;83;4;13;0
+WireConnection;83;5;12;0
+ASEEND*/
+//CHKSM=EC822472A6313A32E5127FEC5369A7CEABC7478D

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurface.shader.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurface.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 75b202cd6c96bf144b1ad251052c51e7
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurfaceCutout.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurfaceCutout.shader
@@ -1,12 +1,13 @@
-// Upgrade NOTE: upgraded instancing buffer 'AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha' to new syntax.
+// Upgrade NOTE: upgraded instancing buffer 'AudioLinkSurfaceAudioReactiveSurface_Cutout' to new syntax.
 
 // Made with Amplify Shader Editor
 // Available at the Unity Asset Store - http://u3d.as/y3X
-Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
+Shader "AudioLink/Amplify/AudioReactiveSurface_Cutout"
 {
 	Properties
 	{
 		_MainTex("Albedo", 2D) = "white" {}
+		_Cutoff("Cutoff", Float) = 0.5
 		_Color("Color", Color) = (0.4980392,0.4980392,0.4980392,1)
 		_Metallic("Metallic", Range( 0 , 1)) = 0
 		_Smoothness("Smoothness", Range( 0 , 1)) = 0.5
@@ -157,8 +158,13 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 		}
 		ENDCG
 
+
 		Pass
 		{
+
+			Name "ForwardBase"
+			Tags { "LightMode"="ForwardBase" }
+
 			Blend SrcAlpha OneMinusSrcAlpha
 
 			CGPROGRAM
@@ -169,6 +175,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
 			#pragma multi_compile_fog
 			#define ASE_FOG 1
+			#define _ALPHATEST_ON 1
 
 			#pragma vertex vert
 			#pragma fragment frag
@@ -266,26 +273,27 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			uniform sampler2D _EmissionMap;
 			uniform float _Metallic;
 			uniform float _Smoothness;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			uniform float _Cutoff;
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
 
 			float3 HSVToRGB( float3 c )
@@ -553,7 +561,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				o.Smoothness = _Smoothness;
 				o.Occlusion = 1;
 				o.Alpha = alpha98;
-				float AlphaClipThreshold = 0.5;
+				float AlphaClipThreshold = _Cutoff;
 				float AlphaClipThresholdShadow = 0.5;
 				float3 BakedGI = 0;
 				float3 RefractionColor = 1;
@@ -692,6 +700,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			ENDCG
 		}
 
+
 		Pass
 		{
 
@@ -708,6 +717,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
 			#pragma multi_compile_fog
 			#define ASE_FOG 1
+			#define _ALPHATEST_ON 1
 
 			#pragma vertex vert
 			#pragma fragment frag
@@ -799,26 +809,27 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			uniform sampler2D _EmissionMap;
 			uniform float _Metallic;
 			uniform float _Smoothness;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			uniform float _Cutoff;
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
 
 			float3 HSVToRGB( float3 c )
@@ -1067,7 +1078,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				o.Smoothness = _Smoothness;
 				o.Occlusion = 1;
 				o.Alpha = alpha98;
-				float AlphaClipThreshold = 0.5;
+				float AlphaClipThreshold = _Cutoff;
 				float3 Transmission = 1;
 				float3 Translucency = 1;
 
@@ -1175,6 +1186,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
 			#pragma multi_compile_fog
 			#define ASE_FOG 1
+			#define _ALPHATEST_ON 1
 
 			#pragma vertex vert
 			#pragma fragment frag
@@ -1256,26 +1268,27 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			uniform sampler2D _EmissionMap;
 			uniform float _Metallic;
 			uniform float _Smoothness;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			uniform float _Cutoff;
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
 
 			float3 HSVToRGB( float3 c )
@@ -1525,7 +1538,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				o.Smoothness = _Smoothness;
 				o.Occlusion = 1;
 				o.Alpha = alpha98;
-				float AlphaClipThreshold = 0.5;
+				float AlphaClipThreshold = _Cutoff;
 				float3 BakedGI = 0;
 
 				#ifdef _ALPHATEST_ON
@@ -1631,6 +1644,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
 			#pragma multi_compile_fog
 			#define ASE_FOG 1
+			#define _ALPHATEST_ON 1
 
 			#pragma vertex vert
 			#pragma fragment frag
@@ -1693,24 +1707,25 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			uniform sampler2D _MainTex;
 			uniform float4 _Color;
 			uniform sampler2D _EmissionMap;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			uniform float _Cutoff;
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
+#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
 				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
 
 			float3 HSVToRGB( float3 c )
@@ -1923,7 +1938,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				o.Normal = fixed3( 0, 0, 1 );
 				o.Emission = ( hsvTorgb45 * _Emission_Instance );
 				o.Alpha = alpha98;
-				float AlphaClipThreshold = 0.5;
+				float AlphaClipThreshold = _Cutoff;
 
 				#ifdef _ALPHATEST_ON
 					clip( o.Alpha - AlphaClipThreshold );
@@ -1964,6 +1979,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			#pragma multi_compile __ LOD_FADE_CROSSFADE
 			#pragma multi_compile_fog
 			#define ASE_FOG 1
+			#define _ALPHATEST_ON 1
 
 			#pragma vertex vert
 			#pragma fragment frag
@@ -2021,8 +2037,9 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				float _TessMaxDisp;
 			#endif
 			uniform sampler2D _MainTex;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
+			uniform float _Cutoff;
+			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
 
 
@@ -2173,7 +2190,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 				o.Normal = fixed3( 0, 0, 1 );
 				o.Occlusion = 1;
 				o.Alpha = alpha98;
-				float AlphaClipThreshold = 0.5;
+				float AlphaClipThreshold = _Cutoff;
 				float AlphaClipThresholdShadow = 0.5;
 
 				#ifdef _ALPHATEST_SHADOW_ON
@@ -2206,148 +2223,109 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			}
 			ENDCG
 		}
-        Pass
-        {
-            Name "DepthOnly"
-            Tags{"LightMode" = "DepthOnly"}
-
-            ZWrite On
-            ColorMask 0
-            Cull Back
-            Blend SrcAlpha OneMinusSrcAlpha
-
-            CGPROGRAM
-            #pragma vertex vert
-            #pragma fragment frag
-            #pragma multi_compile_instancing
-            #include "UnityCG.cginc"
-            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
-
-            struct appdata
-            {
-                float4 vertex : POSITION;
-                float4 texcoord : TEXCOORD0;
-                UNITY_VERTEX_INPUT_INSTANCE_ID
-            };
-
-            struct v2f
-            {
-                float4 vertex : SV_POSITION;
-                float2 texcoord : TEXCOORD0;
-                UNITY_VERTEX_INPUT_INSTANCE_ID
-                UNITY_VERTEX_OUTPUT_STEREO
-            };
-
-            sampler2D _MainTex;
-
-            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-
-            v2f vert(appdata v)
-            {
-                v2f o;
-                UNITY_SETUP_INSTANCE_ID(v);
-                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                UNITY_TRANSFER_INSTANCE_ID(v, o);
-                o.vertex = UnityObjectToClipPos(v.vertex);
-                o.texcoord = v.texcoord.xy;
-                return o;
-            }
-
-            float4 frag(v2f i) : SV_TARGET
-            {
-                UNITY_SETUP_INSTANCE_ID(i);
-                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
-
-                float4 tex2DNode4 = tex2D(_MainTex, i.texcoord);
-                float alpha = tex2DNode4.a;
-
-                #if defined(_ALPHATEST_ON)
-                    clip(alpha - 0.5);
-                #endif
-
-                return 0;
-            }
-            ENDCG
-        }
-
-        // DepthNormals pass
-        Pass
-        {
-            Name "DepthNormals"
-            Tags{"LightMode" = "DepthNormals"}
-
-            ZWrite On
-            Cull Back
-            Blend SrcAlpha OneMinusSrcAlpha
-
-            CGPROGRAM
-            #pragma vertex vert
-            #pragma fragment frag
-            #pragma multi_compile_instancing
-            #include "UnityCG.cginc"
-            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
-
-            struct appdata
-            {
-                float4 vertex : POSITION;
-                float3 normal : NORMAL;
-                float4 tangent : TANGENT;
-                float4 texcoord : TEXCOORD0;
-                UNITY_VERTEX_INPUT_INSTANCE_ID
-            };
-
-            struct v2f
-            {
-                float4 vertex : SV_POSITION;
-                float2 texcoord : TEXCOORD0;
-                float3 normal : TEXCOORD1;
-                UNITY_VERTEX_INPUT_INSTANCE_ID
-                UNITY_VERTEX_OUTPUT_STEREO
-            };
-
-            sampler2D _MainTex;
-            sampler2D _BumpMap;
-            float _BumpScale;
-
-            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-            #define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha
-            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_SmoothAlpha)
-
-            v2f vert(appdata v)
-            {
-                v2f o;
-                UNITY_SETUP_INSTANCE_ID(v);
-                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                UNITY_TRANSFER_INSTANCE_ID(v, o);
-                o.vertex = UnityObjectToClipPos(v.vertex);
-                o.texcoord = v.texcoord.xy;
-                o.normal = UnityObjectToWorldNormal(v.normal);
-                return o;
-            }
-
-            float4 frag(v2f i) : SV_TARGET
-            {
-                UNITY_SETUP_INSTANCE_ID(i);
-                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
-
-                float4 tex2DNode4 = tex2D(_MainTex, i.texcoord);
-                float alpha = tex2DNode4.a;
-
-                #if defined(_ALPHATEST_ON)
-                    clip(alpha - 0.5);
-                #endif
-
-                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
-                float2 uv_BumpMap = i.texcoord * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
-                float3 normalMap = UnpackNormal(tex2D(_BumpMap, uv_BumpMap));
-                float3 normal = normalize(normalMap * float3(_BumpScale, _BumpScale, 1.0));
-
-                return float4(normal * 0.5 + 0.5, 1);
-            }
-            ENDCG
-        }
 
 	}
+	CustomEditor "ASEMaterialInspector"
+
+
 }
+/*ASEBEGIN
+Version=18908
+3114.4;81.6;2712;1462;2419.09;511.9547;1.305492;True;False
+Node;AmplifyShaderEditor.TextureCoordinatesNode;6;-1357,-367;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SamplerNode;4;-1039,-416;Inherit;True;Property;_MainTex;Albedo;0;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;white;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.RegisterLocalVarNode;98;-616.8574,-440.1531;Inherit;False;alpha;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.HSVToRGBNode;45;252.8217,636.5342;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.RegisterLocalVarNode;36;-599.8431,921.3793;Inherit;False;amplitude;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;13;258.2,923.202;Inherit;False;Property;_Metallic;Metallic;3;0;Create;True;0;0;0;False;0;False;0;0.5;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SamplerNode;14;-989.8879,298.6613;Inherit;True;Property;_EmissionMap;Emission Map;7;0;Create;True;0;0;0;False;0;False;-1;None;None;True;0;False;gray;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.GetLocalVarNode;41;-311.1783,767.5342;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;17;-1434.696,642.8046;Inherit;False;InstancedProperty;_Band;Band;10;2;[Header];[IntRange];Create;True;1;Audio Section;0;0;False;0;False;0;0;0;3;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleAddOpNode;35;8.705078,-321.8591;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.GetLocalVarNode;42;-304.7005,662.272;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.BreakToComponentsNode;78;-1694.509,804.9429;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.FunctionNode;93;-1490.614,908.6327;Inherit;False;BandPulse;-1;;9;c478702160369ce4480fa2fb6d734ffa;0;3;1;FLOAT;0;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.FunctionNode;69;-1965.055,774.2052;Inherit;False;RotateUVFill;-1;;10;459952d587cbfe742a7e7f4a8a0a4169;0;2;1;FLOAT2;0,0;False;2;FLOAT;0;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.RangedFloatNode;18;-1829.046,1036.233;Inherit;False;InstancedProperty;_Delay;Delay;11;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;57;-1829.967,934.3949;Inherit;False;InstancedProperty;_Pulse;Pulse;12;1;[Header];Create;True;1;Pulse Across UVs;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RadiansOpNode;51;-2161.509,869.1142;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;49;-2459.856,880.3222;Inherit;False;InstancedProperty;_PulseRotation;Pulse Rotation;14;0;Create;True;0;0;0;False;0;False;0;0;0;360;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;11;-502,92;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.RangedFloatNode;31;-1390.638,-584.899;Inherit;False;InstancedProperty;_AudioHueShift;Audio Hue Shift;13;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;101;-1214.774,934.5303;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;128;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;12;261.2,1021.201;Inherit;False;Property;_Smoothness;Smoothness;4;0;Create;True;0;0;0;False;0;False;0.5;0.5;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SamplerNode;9;-936,-2;Inherit;True;Property;_BumpMap;Normal Map;5;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;bump;Auto;True;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.TextureCoordinatesNode;50;-2463.205,741.2821;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.RGBToHSVNode;40;-310.7005,431.272;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.GetLocalVarNode;34;-366.2949,-141.8591;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;10;-812,202;Inherit;False;Property;_BumpScale;Normal Scale;6;0;Create;False;0;0;0;False;0;False;1;1;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.GetLocalVarNode;37;-372.7727,-36.59692;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;43;-91.17834,730.5342;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleAddOpNode;44;70.29944,482.272;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;38;-152.7727,-73.59692;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RegisterLocalVarNode;33;-1046.295,-583.8591;Inherit;False;hueShift;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;5;-597,-280;Inherit;False;2;2;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;1;COLOR;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;15;-528.8879,636.6613;Inherit;False;3;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.RGBToHSVNode;32;-372.2949,-372.8591;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.RangedFloatNode;100;400.1211,1268.736;Inherit;False;Property;_Cutoff;Cutoff;1;0;Create;True;0;0;0;False;0;False;0.5;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;2;-955,-202.5;Inherit;False;Property;_Color;Color;2;0;Create;True;0;0;0;False;0;False;0.4980392,0.4980392,0.4980392,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.HSVToRGBNode;39;191.2273,-167.5969;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.RangedFloatNode;46;255.5175,800.3702;Inherit;False;InstancedProperty;_Emission;Emission Scale;9;0;Create;False;0;0;0;False;0;False;1;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;47;534.9175,735.4701;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.FunctionNode;96;-976.309,831.6292;Inherit;False;4BandAmplitudeLerp;-1;;8;3cf4b6e83381a9a4f84f8cf857bc3af5;0;2;2;INT;0;False;4;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.GetLocalVarNode;99;353.124,1122.521;Inherit;False;98;alpha;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;3;-935.8119,580.942;Inherit;False;InstancedProperty;_EmissionColor;Emission Color;8;1;[HDR];Create;True;0;0;0;False;0;False;0,0,0,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;83;895.8018,686.1933;Float;False;True;-1;2;ASEMaterialInspector;0;10;AudioLink/Surface/AudioReactiveSurface_Cutout;f0be08cf82190c945883605df227bec5;True;ForwardBase;0;1;ForwardBase;18;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;2;False;-1;True;3;False;-1;False;True;3;RenderType=Transparent=RenderType;Queue=Transparent=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;5;False;-1;10;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;40;Workflow,InvertActionOnDeselection;1;Surface;1;  Blend;0;  Refraction Model;0;  Dither Shadows;1;Two Sided;1;Deferred Pass;1;Transmission;0;  Transmission Shadow;0.5,False,-1;Translucency;0;  Translucency Strength;1,False,-1;  Normal Distortion;0.5,False,-1;  Scattering;2,False,-1;  Direct;0.9,False,-1;  Ambient;0.1,False,-1;  Shadow;0.5,False,-1;Cast Shadows;1;  Use Shadow Threshold;0;Receive Shadows;1;GPU Instancing;1;LOD CrossFade;1;Built-in Fog;1;Ambient Light;1;Meta Pass;1;Add Pass;1;Override Baked GI;0;Extra Pre Pass;0;Tessellation;0;  Phong;0;  Strength;0.5,False,-1;  Type;0;  Tess;16,False,-1;  Min;10,False,-1;  Max;25,False,-1;  Edge Length;16,False,-1;  Max Displacement;25,False,-1;Fwd Specular Highlights Toggle;0;Fwd Reflections Toggle;0;Disable Batching;0;Vertex Position,InvertActionOnDeselection;1;0;6;False;True;True;True;True;True;False;;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;85;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Deferred;0;3;Deferred;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Deferred;True;2;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;82;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ExtraPrePass;0;0;ExtraPrePass;6;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;True;True;0;False;-1;0;False;-1;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;86;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Meta;0;4;Meta;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Meta;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;87;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ShadowCaster;0;5;ShadowCaster;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;False;-1;True;3;False;-1;False;True;1;LightMode=ShadowCaster;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;84;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ForwardAdd;0;2;ForwardAdd;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;4;5;False;-1;1;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;True;1;LightMode=ForwardAdd;False;0;;0;0;Standard;0;False;0
+WireConnection;4;1;6;0
+WireConnection;98;0;4;4
+WireConnection;45;0;44;0
+WireConnection;45;1;40;2
+WireConnection;45;2;40;3
+WireConnection;36;0;96;0
+WireConnection;35;0;32;1
+WireConnection;35;1;38;0
+WireConnection;78;0;69;0
+WireConnection;93;1;78;0
+WireConnection;93;2;57;0
+WireConnection;93;3;18;0
+WireConnection;69;1;50;0
+WireConnection;69;2;51;0
+WireConnection;51;0;49;0
+WireConnection;11;0;9;0
+WireConnection;11;1;10;0
+WireConnection;101;0;93;0
+WireConnection;40;0;15;0
+WireConnection;43;0;42;0
+WireConnection;43;1;41;0
+WireConnection;44;0;40;1
+WireConnection;44;1;43;0
+WireConnection;38;0;34;0
+WireConnection;38;1;37;0
+WireConnection;33;0;31;0
+WireConnection;5;0;4;0
+WireConnection;5;1;2;0
+WireConnection;15;0;14;0
+WireConnection;15;1;3;0
+WireConnection;15;2;96;0
+WireConnection;32;0;5;0
+WireConnection;39;0;35;0
+WireConnection;39;1;32;2
+WireConnection;39;2;32;3
+WireConnection;47;0;45;0
+WireConnection;47;1;46;0
+WireConnection;96;2;17;0
+WireConnection;96;4;101;0
+WireConnection;83;0;39;0
+WireConnection;83;1;11;0
+WireConnection;83;2;47;0
+WireConnection;83;4;13;0
+WireConnection;83;5;12;0
+WireConnection;83;7;99;0
+WireConnection;83;8;100;0
+ASEEND*/
+//CHKSM=B4ACAD35915A34A62FB02B0FFB35F6EAC36F4E5A

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurfaceCutout.shader.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurfaceCutout.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: bfb57ac73abf48f4b95171f3c88fd46c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurfaceSmoothAlpha.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurfaceSmoothAlpha.shader
@@ -2,7 +2,7 @@
 
 // Made with Amplify Shader Editor
 // Available at the Unity Asset Store - http://u3d.as/y3X
-Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
+Shader "AudioLink/Amplify/AudioReactiveSurface_SmoothAlpha"
 {
 	Properties
 	{
@@ -157,8 +157,12 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 		}
 		ENDCG
 
+
 		Pass
 		{
+
+			Name "ForwardBase"
+
 			Blend SrcAlpha OneMinusSrcAlpha
 
 			CGPROGRAM
@@ -691,6 +695,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
 			}
 			ENDCG
 		}
+
 
 		Pass
 		{
@@ -2350,4 +2355,105 @@ Shader "AudioLink/Surface/AudioReactiveSurface_SmoothAlpha"
         }
 
 	}
+	CustomEditor "ASEMaterialInspector"
+
+
 }
+/*ASEBEGIN
+Version=18908
+3114.4;81.6;2712;1462;2248.071;776.9701;1.305492;True;False
+Node;AmplifyShaderEditor.TextureCoordinatesNode;6;-1357,-367;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SamplerNode;4;-1039,-416;Inherit;True;Property;_MainTex;Albedo;0;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;white;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.RegisterLocalVarNode;98;-616.8574,-440.1531;Inherit;False;alpha;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleAddOpNode;35;8.705078,-321.8591;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.GetLocalVarNode;99;353.124,1122.521;Inherit;False;98;alpha;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.GetLocalVarNode;41;-311.1783,767.5342;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleAddOpNode;44;70.29944,482.272;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;38;-152.7727,-73.59692;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.BreakToComponentsNode;78;-1646.205,786.666;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.RangedFloatNode;12;261.2,1021.201;Inherit;False;Property;_Smoothness;Smoothness;3;0;Create;True;0;0;0;False;0;False;0.5;0.5;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RadiansOpNode;51;-2113.206,850.8373;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;18;-1780.743,1017.956;Inherit;False;InstancedProperty;_Delay;Delay;10;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;57;-1781.663,916.118;Inherit;False;InstancedProperty;_Pulse;Pulse;11;1;[Header];Create;True;1;Pulse Across UVs;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.FunctionNode;93;-1442.31,890.3558;Inherit;False;BandPulse;-1;;9;c478702160369ce4480fa2fb6d734ffa;0;3;1;FLOAT;0;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;49;-2411.553,862.0453;Inherit;False;InstancedProperty;_PulseRotation;Pulse Rotation;13;0;Create;True;0;0;0;False;0;False;0;0;0;360;0;1;FLOAT;0
+Node;AmplifyShaderEditor.TextureCoordinatesNode;50;-2414.902,723.0052;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;15;-528.8879,636.6613;Inherit;False;3;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.FunctionNode;69;-1916.752,755.9283;Inherit;False;RotateUVFill;-1;;10;459952d587cbfe742a7e7f4a8a0a4169;0;2;1;FLOAT2;0,0;False;2;FLOAT;0;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.RangedFloatNode;31;-1390.638,-584.899;Inherit;False;InstancedProperty;_AudioHueShift;Audio Hue Shift;12;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SamplerNode;14;-989.8879,298.6613;Inherit;True;Property;_EmissionMap;Emission Map;6;0;Create;True;0;0;0;False;0;False;-1;None;None;True;0;False;gray;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;11;-502,92;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.GetLocalVarNode;42;-304.7005,662.272;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;47;534.9175,735.4701;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.GetLocalVarNode;34;-366.2949,-141.8591;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;5;-597,-280;Inherit;False;2;2;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;1;COLOR;0
+Node;AmplifyShaderEditor.ColorNode;2;-955,-202.5;Inherit;False;Property;_Color;Color;1;0;Create;True;0;0;0;False;0;False;0.4980392,0.4980392,0.4980392,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.RegisterLocalVarNode;33;-1046.295,-583.8591;Inherit;False;hueShift;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;13;258.2,923.202;Inherit;False;Property;_Metallic;Metallic;2;0;Create;True;0;0;0;False;0;False;0;0.5;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;17;-1434.696,642.8046;Inherit;False;InstancedProperty;_Band;Band;9;2;[Header];[IntRange];Create;True;1;Audio Section;0;0;False;0;False;0;0;0;3;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;10;-812,202;Inherit;False;Property;_BumpScale;Normal Scale;5;0;Create;False;0;0;0;False;0;False;1;1;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RGBToHSVNode;32;-372.2949,-372.8591;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;100;-1162.554,904.5041;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;128;False;1;FLOAT;0
+Node;AmplifyShaderEditor.HSVToRGBNode;45;252.8217,636.5342;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.GetLocalVarNode;37;-372.7727,-36.59692;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RegisterLocalVarNode;36;-599.8431,921.3793;Inherit;False;amplitude;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SamplerNode;9;-936,-2;Inherit;True;Property;_BumpMap;Normal Map;4;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;bump;Auto;True;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.RangedFloatNode;46;255.5175,800.3702;Inherit;False;InstancedProperty;_Emission;Emission Scale;8;0;Create;False;0;0;0;False;0;False;1;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RGBToHSVNode;40;-310.7005,431.272;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.FunctionNode;96;-976.309,831.6292;Inherit;False;4BandAmplitudeLerp;-1;;8;3cf4b6e83381a9a4f84f8cf857bc3af5;0;2;2;INT;0;False;4;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.HSVToRGBNode;39;191.2273,-167.5969;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;43;-91.17834,730.5342;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;3;-935.8119,580.942;Inherit;False;InstancedProperty;_EmissionColor;Emission Color;7;1;[HDR];Create;True;0;0;0;False;0;False;0,0,0,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;84;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ForwardAdd;0;2;ForwardAdd;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;4;5;False;-1;1;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;True;1;LightMode=ForwardAdd;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;86;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Meta;0;4;Meta;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Meta;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;87;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ShadowCaster;0;5;ShadowCaster;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;False;-1;True;3;False;-1;False;True;1;LightMode=ShadowCaster;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;85;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Deferred;0;3;Deferred;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Deferred;True;2;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;82;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ExtraPrePass;0;0;ExtraPrePass;6;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;True;True;0;False;-1;0;False;-1;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;83;895.8018,686.1933;Float;False;True;-1;2;ASEMaterialInspector;0;10;AudioLink/Surface/AudioReactiveSurface_SmoothAlpha;f0be08cf82190c945883605df227bec5;True;ForwardBase;0;1;ForwardBase;18;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;2;False;-1;True;3;False;-1;False;True;3;RenderType=Transparent=RenderType;Queue=Transparent=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;5;False;-1;10;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;40;Workflow,InvertActionOnDeselection;1;Surface;1;  Blend;0;  Refraction Model;0;  Dither Shadows;1;Two Sided;1;Deferred Pass;1;Transmission;0;  Transmission Shadow;0.5,False,-1;Translucency;0;  Translucency Strength;1,False,-1;  Normal Distortion;0.5,False,-1;  Scattering;2,False,-1;  Direct;0.9,False,-1;  Ambient;0.1,False,-1;  Shadow;0.5,False,-1;Cast Shadows;1;  Use Shadow Threshold;0;Receive Shadows;1;GPU Instancing;1;LOD CrossFade;1;Built-in Fog;1;Ambient Light;1;Meta Pass;1;Add Pass;1;Override Baked GI;0;Extra Pre Pass;0;Tessellation;0;  Phong;0;  Strength;0.5,False,-1;  Type;0;  Tess;16,False,-1;  Min;10,False,-1;  Max;25,False,-1;  Edge Length;16,False,-1;  Max Displacement;25,False,-1;Fwd Specular Highlights Toggle;0;Fwd Reflections Toggle;0;Disable Batching;0;Vertex Position,InvertActionOnDeselection;1;0;6;False;True;True;True;True;True;False;;False;0
+WireConnection;4;1;6;0
+WireConnection;98;0;4;4
+WireConnection;35;0;32;1
+WireConnection;35;1;38;0
+WireConnection;44;0;40;1
+WireConnection;44;1;43;0
+WireConnection;38;0;34;0
+WireConnection;38;1;37;0
+WireConnection;78;0;69;0
+WireConnection;51;0;49;0
+WireConnection;93;1;78;0
+WireConnection;93;2;57;0
+WireConnection;93;3;18;0
+WireConnection;15;0;14;0
+WireConnection;15;1;3;0
+WireConnection;15;2;96;0
+WireConnection;69;1;50;0
+WireConnection;69;2;51;0
+WireConnection;11;0;9;0
+WireConnection;11;1;10;0
+WireConnection;47;0;45;0
+WireConnection;47;1;46;0
+WireConnection;5;0;4;0
+WireConnection;5;1;2;0
+WireConnection;33;0;31;0
+WireConnection;32;0;5;0
+WireConnection;100;0;93;0
+WireConnection;45;0;44;0
+WireConnection;45;1;40;2
+WireConnection;45;2;40;3
+WireConnection;36;0;96;0
+WireConnection;40;0;15;0
+WireConnection;96;2;17;0
+WireConnection;96;4;100;0
+WireConnection;39;0;35;0
+WireConnection;39;1;32;2
+WireConnection;39;2;32;3
+WireConnection;43;0;42;0
+WireConnection;43;1;41;0
+WireConnection;83;0;39;0
+WireConnection;83;1;11;0
+WireConnection;83;2;47;0
+WireConnection;83;4;13;0
+WireConnection;83;5;12;0
+WireConnection;83;7;99;0
+ASEEND*/
+//CHKSM=CE016AEA82EA9E9E82F18C485824FE472208DA11

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurfaceSmoothAlpha.shader.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders/AudioLinkAmplify_ReactiveSurfaceSmoothAlpha.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ae33cd5657d97ea4198558b6c91d0e3e
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkAutocorrView.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkAutocorrView.shader
@@ -63,29 +63,29 @@
             float _ColorChordRange;
             float _Brightness;
             float _Fadeyness;
-            
+
             float _BubbleOffset;
             float _XOffset;
             float _YOffset;
             float _BubbleRotationSpeed;
             float _BubbleRotationMultiply;
             float _BubbleRotationOffset;
-            
-            v2f vert (appdata v)
+
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
-                UNITY_TRANSFER_FOG(o,o.vertex);
+                UNITY_TRANSFER_FOG(o, o.vertex);
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
                 float2 uvCenter = float2(i.uv.x - _XOffset, i.uv.y - _YOffset) * 2 - 1;
 
@@ -93,22 +93,22 @@
                 float angle = atan2(uvCenter.x, uvCenter.y) / UNITY_PI;
                 angle = glsl_mod(angle * _BubbleRotationMultiply + _BubbleRotationSpeed * _Time.y + _BubbleRotationOffset, 2.0);
                 float angleDelta = abs(angle - 1.0) * (AUDIOLINK_WIDTH - 1);
-                
+
                 // Read autocorrelator value, apply normalization
                 float sinCoord = lerp(abs(uvCenter.x * AUDIOLINK_WIDTH), angleDelta, _AutocorrRound);
                 float sinVal = AudioLinkLerpMultiline(ALPASS_AUTOCORRELATOR + float2(sinCoord, 0));
-                sinVal *= lerp(1.0, rsqrt(AudioLinkData( ALPASS_AUTOCORRELATOR ).r), _AutocorrNormalization);
+                sinVal *= lerp(1.0, rsqrt(AudioLinkData(ALPASS_AUTOCORRELATOR).r), _AutocorrNormalization);
                 sinVal *= _AutocorrIntensity;
-                
+
                 // Get distance to circle, subtract from autocorrelator value
                 float dist = lerp(abs(uvCenter.y), length(uvCenter), _AutocorrRound) - _BubbleOffset;
                 dist = sinVal - dist;
-                
+
                 // Fetch colorchord data, lerp to chosen colors
                 float4 mainColor = lerp(_ColorBackground, _ColorForeground, dist > 0);
                 float3 colorChordColor = AudioLinkData(int2(ALPASS_CCSTRIP + int2(clamp(abs(dist * _ColorChordRange), 0, AUDIOLINK_WIDTH - 1), 0)));
                 float3 color = lerp(mainColor.rgb, colorChordColor.rgb, _ColorChord);
-                
+
                 // Apply fade, brightness, fog
                 color *= lerp(1, dist, _Fadeyness);
                 color *= _Brightness;
@@ -116,6 +116,120 @@
                 UNITY_APPLY_FOG(i.fogCoord, finalColor);
 
                 return saturate(finalColor);
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            float _XOffset;
+            float _YOffset;
+            float _BubbleOffset;
+            float _AutocorrRound;
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            float _XOffset;
+            float _YOffset;
+            float _BubbleOffset;
+            float _AutocorrRound;
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normal : TEXCOORD1;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkController.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkController.shader
@@ -8,6 +8,337 @@
     }
     SubShader
     {
+        Tags { "RenderType"="Opaque" "RenderPipeline"="UniversalPipeline" }
+        LOD 200
+
+        // Main pass
+        Pass
+        {
+            Name "ForwardLit"
+            Tags { "LightMode" = "UniversalForward" }
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS_CASCADE
+            #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile_fog
+            #pragma target 3.0
+
+            #if UNIVERSAL_RENDER_PIPELINE
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                float4 positionOS   : POSITION;
+                float2 uv           : TEXCOORD0;
+                float3 normalOS     : NORMAL;
+                float4 tangentOS    : TANGENT;
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                #endif
+            };
+
+            struct Varyings
+            {
+                float2 uv           : TEXCOORD0;
+                float4 positionCS   : SV_POSITION;
+                float3 positionWS   : TEXCOORD1;
+                float3 normalWS     : TEXCOORD2;
+                float4 shadowCoord  : TEXCOORD3;
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_VERTEX_OUTPUT_STEREO
+                #endif
+            };
+
+            #if UNIVERSAL_RENDER_PIPELINE
+            TEXTURE2D(_MainTex);
+            SAMPLER(sampler_MainTex);
+            TEXTURE2D(_Metallic);
+            SAMPLER(sampler_Metallic);
+
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _Color;
+            CBUFFER_END
+            #endif
+
+            Varyings vert(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_SETUP_INSTANCE_ID(v); //Insert
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o); //Insert
+                // Transform position and normals
+                VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+                VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+                output.positionCS = vertexInput.positionCS;
+                output.positionWS = vertexInput.positionWS;
+                output.normalWS = normalInput.normalWS;
+                output.uv = TRANSFORM_TEX(input.uv, _MainTex);
+
+                // Get shadow coordinates
+                output.shadowCoord = GetShadowCoord(vertexInput);
+                #endif
+
+                return output;
+            }
+
+            half4 frag(Varyings input) : SV_Target
+            {
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+                // Sample textures
+                half4 c = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv) * _Color;
+                half4 b = SAMPLE_TEXTURE2D(_Metallic, sampler_Metallic, input.uv);
+
+                // Setup standard PBR inputs
+                float3 normalWS = normalize(input.normalWS);
+                float3 viewDirWS = normalize(GetWorldSpaceViewDir(input.positionWS));
+
+                // Create InputData for URP's fragment lighting function
+                InputData inputData;
+                inputData.positionWS = input.positionWS;
+                inputData.normalWS = normalWS;
+                inputData.viewDirectionWS = viewDirWS;
+                inputData.shadowCoord = TransformWorldToShadowCoord(input.positionWS);
+                inputData.fogCoord = ComputeFogFactor(input.positionCS.z);
+                inputData.vertexLighting = half3(0, 0, 0);
+                inputData.bakedGI = SampleSH(normalWS);
+                inputData.normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(input.positionCS);
+                inputData.shadowMask = half4(1, 1, 1, 1);
+
+                // Setup SurfaceData for URP PBR lighting
+                SurfaceData surfaceData;
+                surfaceData.albedo = c.rgb;
+                surfaceData.metallic = b.r;
+                surfaceData.specular = half3(0, 0, 0);
+                surfaceData.smoothness = b.a;
+                surfaceData.occlusion = b.g;
+                surfaceData.emission = half3(0, 0, 0);
+                surfaceData.alpha = c.a;
+                surfaceData.clearCoatMask = 0;
+                surfaceData.clearCoatSmoothness = 0;
+                surfaceData.normalTS = half3(0, 0, 1);
+
+                // Use URP's standard lighting function
+                half4 color = UniversalFragmentPBR(inputData, surfaceData);
+
+                // Apply fog
+                color.rgb = MixFog(color.rgb, inputData.fogCoord);
+
+                return color;
+                #else
+                return (0).xxxx;
+                #endif
+            }
+            ENDHLSL
+        }
+
+        // Shadow casting pass
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags { "LightMode" = "ShadowCaster" }
+
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+            Cull Back
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 3.0
+
+            #if UNIVERSAL_RENDER_PIPELINE
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/ShadowCasterPass.hlsl"
+
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _Color;
+            CBUFFER_END
+
+            #else
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+            };
+
+            #endif
+
+            Varyings vert(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if UNIVERSAL_RENDER_PIPELINE
+                return ShadowPassVertex(input);
+                #else
+                return output;
+                #endif
+            }
+
+            half4 frag(Varyings input) : SV_TARGET
+            {
+                #if UNIVERSAL_RENDER_PIPELINE
+                return ShadowPassFragment(input);
+                #else
+                return 0;
+                #endif
+            }
+
+            ENDHLSL
+        }
+
+        // Depth-only pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags { "LightMode" = "DepthOnly" }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 3.0
+
+            #if UNIVERSAL_RENDER_PIPELINE
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthOnlyPass.hlsl"
+
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _Color;
+            CBUFFER_END
+
+            #else
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+            };
+
+            #endif
+
+            Varyings vert(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if UNIVERSAL_RENDER_PIPELINE
+                return DepthOnlyVertex(input);
+                #else
+                return output;
+                #endif
+            }
+
+            half4 frag(Varyings input) : SV_TARGET
+            {
+                #if UNIVERSAL_RENDER_PIPELINE
+                return DepthOnlyFragment(input);
+                #else
+                return 0;
+                #endif
+            }
+            ENDHLSL
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags { "LightMode" = "DepthNormals" }
+
+            ZWrite On
+            Cull Back
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 3.0
+
+            // This is a custom depth normals pass
+            #if UNIVERSAL_RENDER_PIPELINE
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthNormalsPass.hlsl"
+
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _Color;
+            CBUFFER_END
+
+            #else
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+            };
+
+            #endif
+
+            Varyings vert(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if UNIVERSAL_RENDER_PIPELINE
+                return DepthNormalsVertex(input);
+                #else
+                return output;
+                #endif
+            }
+
+            void frag(Varyings input, out half4 outNormalWS : SV_Target0
+            #ifdef _WRITE_RENDERING_LAYERS
+                , out float4 outRenderingLayers : SV_Target1
+            #endif
+            )
+            {
+                #if UNIVERSAL_RENDER_PIPELINE
+                DepthNormalsFragment(input, outNormalWS
+                    #ifdef _WRITE_RENDERING_LAYERS
+                    , outRenderingLayers : SV_Target1
+                    #endif
+                );
+                #else
+                outNormalWS = (0).xxxx;
+                #endif
+            }
+            ENDHLSL
+        }
+    }
+
+    SubShader
+    {
         Tags { "RenderType"="Opaque" }
 
         CGPROGRAM

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkControllerLogo.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkControllerLogo.shader
@@ -11,6 +11,82 @@ Shader "AudioLink/Internal/AudioLinkControllerLogo"
 
     SubShader
     {
+        Tags {
+            "RenderType" = "Custom"
+            "Queue" = "Transparent+0"
+            "IgnoreProjector" = "True"
+            "RenderingPipeline" = "UniversalPipeline"
+        }
+        Cull Off
+        ZWrite On
+        Blend One One
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+            #include "AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            float4 _BaseColor;
+            float _PulseWidth;
+            float _PulseOffsetQ;
+            float _Gain;
+            float _QPower;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+                float2 uv = i.uv;
+
+                float offset = pow(abs(2. * uv.y - 1.) * _PulseOffsetQ, _QPower);
+                float position = abs(2. * uv.x - 1.);
+                float4 bassColor = AudioLinkLerp(ALPASS_AUDIOLINK + float2((position + offset) * _PulseWidth * 128., 0)).r * AudioLinkData(ALPASS_THEME_COLOR0) * smoothstep(1, 0, position);
+                float4 lowMidColor = AudioLinkLerp(ALPASS_AUDIOLINK + float2((position + offset) * _PulseWidth * 128., 1)).r * AudioLinkData(ALPASS_THEME_COLOR3) * smoothstep(1, 0, position);
+                float4 highMidColor = AudioLinkLerp(ALPASS_AUDIOLINK + float2((1 - (position - offset)) * _PulseWidth * 128., 2)).r * AudioLinkData(ALPASS_THEME_COLOR2) * smoothstep(0, 1, position);
+                float4 trebleColor = AudioLinkLerp(ALPASS_AUDIOLINK + float2((1 - (position - offset)) * _PulseWidth * 128., 3)).r * AudioLinkData(ALPASS_THEME_COLOR1) * smoothstep(0, 1, position);
+
+                return saturate(_BaseColor + (bassColor + lowMidColor + highMidColor + trebleColor) * _Gain);
+            }
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
+    SubShader
+    {
         Tags{"RenderType" = "Custom"  "Queue" = "Transparent+0" "IgnoreProjector" = "True"}
         Cull Off
         ZWrite On
@@ -53,7 +129,7 @@ Shader "AudioLink/Internal/AudioLinkControllerLogo"
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
@@ -62,7 +138,7 @@ Shader "AudioLink/Internal/AudioLinkControllerLogo"
             fixed4 frag (v2f i) : SV_Target
             {
                 float2 uv = i.uv;
-                
+
                 float offset = pow(abs(2. * uv.y - 1.) * _PulseOffsetQ, _QPower);
                 float position = abs(2. * uv.x - 1.);
                 float4 bassColor = AudioLinkLerp(ALPASS_AUDIOLINK + float2((position + offset) * _PulseWidth * 128., 0)).r * AudioLinkData(ALPASS_THEME_COLOR0) * smoothstep(1, 0, position);

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo1.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo1.shader
@@ -30,22 +30,118 @@
             };
 
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
-                return AudioLinkData( ALPASS_AUDIOLINK + int2( 0, i.uv.y * 4. ) ).rrrr;
+                return AudioLinkData(ALPASS_AUDIOLINK + int2( 0, i.uv.y * 4. )).rrrr;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo10.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo10.shader
@@ -31,7 +31,7 @@
             };
 
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
@@ -48,52 +48,151 @@
 
             float DFTSample(float bin)
             {
-                float mag = AudioLinkLerpMultiline( ALPASS_DFT + float2( bin, 0 ) ).r;
+                float mag = AudioLinkLerpMultiline(ALPASS_DFT + float2(bin, 0)).r;
                 return mag / (lut[min(bin, 239)] * AUDIOLINK_TREBLE_CORRECTION + 1);
             }
 
             float DFTPhase(float bin)
             {
-                return AudioLinkLerpMultiline( ALPASS_DFT + float2( bin, 0 ) ).a;
+                return AudioLinkLerpMultiline(ALPASS_DFT + float2(bin, 0)).a;
             }
 
             float WaveformSample(float sampleIndex, float period)
             {
-                if (sampleIndex < 0) {
+                if (sampleIndex < 0)
+                {
                     sampleIndex += period * ceil((0 - sampleIndex) / period);
                 }
-                if (sampleIndex >= AUDIOLINK_SAMPLEDATA24) {
+                if (sampleIndex >= AUDIOLINK_SAMPLEDATA24)
+                {
                     sampleIndex -= period * ceil((sampleIndex - AUDIOLINK_SAMPLEDATA24 + 1) / period);
                 }
-                return AudioLinkLerpMultiline( ALPASS_WAVEFORM + float2( sampleIndex, 0 ) ).r;
+                return AudioLinkLerpMultiline(ALPASS_WAVEFORM + float2(sampleIndex, 0)).r;
             }
 
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
-
                 float maxBin = 0;
                 float maxValue = 0;
-                for ( int bin = 0 ; bin < AUDIOLINK_ETOTALBINS; bin++)
+                for (int bin = 0; bin < AUDIOLINK_ETOTALBINS; bin++)
                 {
                     float curValue = DFTSample(bin);
-                    if ( curValue > maxValue )
+                    if (curValue > maxValue)
                     {
                         maxValue = curValue;
                         maxBin = bin;
                     }
                 }
 
-                float period = 24000 / ( pow( 2, maxBin / AUDIOLINK_EXPBINS ) * AUDIOLINK_BOTTOM_FREQUENCY );
+                float period = 24000 / (pow(2, maxBin / AUDIOLINK_EXPBINS) * AUDIOLINK_BOTTOM_FREQUENCY);
                 float phase = DFTPhase(maxBin);
                 float angle = phase / UNITY_TWO_PI;
                 float centerSampleIndex = AUDIOLINK_SAMPHIST * 0.5 -
-                    ( angle + round( ( AUDIOLINK_SAMPHIST - AUDIOLINK_SAMPLEDATA24 ) * 0.5 / period ) ) * period;
+                    (angle + round((AUDIOLINK_SAMPHIST - AUDIOLINK_SAMPLEDATA24) * 0.5 / period)) * period;
 
-                float sampleIndex = lerp( centerSampleIndex - 500, centerSampleIndex + 500, i.uv.x );
-                float sample = WaveformSample( sampleIndex, period );
+                float sampleIndex = lerp(centerSampleIndex - 500, centerSampleIndex + 500, i.uv.x);
+                float sample = WaveformSample(sampleIndex, period);
 
-                return clamp( 1 - 10 * abs( sample - i.uv.y* 2. + 1 ), 0, 1 );
+                return clamp(1 - 10 * abs(sample - i.uv.y * 2. + 1), 0, 1);
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo2.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo2.shader
@@ -31,25 +31,166 @@
             };
 
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
-            {                
-                float Sample = AudioLinkLerpMultiline( ALPASS_WAVEFORM + float2( 200. * i.uv.x, 0 ) ).r;
-                return clamp( 1 - 50 * abs( Sample - i.uv.y* 2. + 1 ), 0, 1 );
+            fixed4 frag(v2f i) : SV_Target
+            {
+                float Sample = AudioLinkLerpMultiline(ALPASS_WAVEFORM + float2(200. * i.uv.x, 0)).r;
+                return clamp(1 - 50 * abs(Sample - i.uv.y * 2. + 1), 0, 1);
             }
             ENDCG
         }
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                float Sample = AudioLinkLerpMultiline(ALPASS_WAVEFORM + float2(200. * i.uv.x, 0)).r;
+                return clamp(1 - 50 * abs(Sample - i.uv.y * 2. + 1), 0, 1);
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
+            }
+            ENDCG
+        }
+
     }
 }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo3.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo3.shader
@@ -33,34 +33,203 @@
             };
 
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
                 float noteno = i.uv.x * AUDIOLINK_ETOTALBINS;
 
-                float4 spectrum_value = -AudioLinkLerpMultiline( ALPASS_DFT + float2( noteno, 0. ) ) * 0.5  + 0.55;
+                float4 spectrum_value = -AudioLinkLerpMultiline(ALPASS_DFT + float2(noteno, 0.)) * 0.5 + 0.55;
 
                 //If we are below the spectrum line, discard the pixel.
-                if( i.uv.y < spectrum_value.z )
+                if (i.uv.y < spectrum_value.z)
                     discard;
-                else if( i.uv.y < spectrum_value.z + 0.01 )
+                else if (i.uv.y < spectrum_value.z + 0.01)
                     return 1.;
 
                 return 0.1;
             }
             ENDCG
         }
+        Pass
+        {
+            Cull Off
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                float noteno = i.uv.x * AUDIOLINK_ETOTALBINS;
+
+                float4 spectrum_value = -AudioLinkLerpMultiline(ALPASS_DFT + float2(noteno, 0.)) * 0.5 + 0.55;
+
+                //If we are below the spectrum line, discard the pixel.
+                if (i.uv.y < spectrum_value.z) discard;
+                if (i.uv.y < spectrum_value.z + 0.01) return 1.;
+
+                return 0.1;
+            }
+            ENDCG
+        }
+
+        // DepthOnly pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            Cull Off
+            ZWrite On
+            ColorMask 0
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float noteno = i.uv.x * AUDIOLINK_ETOTALBINS;
+                float4 spectrum_value = -AudioLinkLerpMultiline(ALPASS_DFT + float2(noteno, 0.)) * 0.5 + 0.55;
+
+                if (i.uv.y < spectrum_value.z) discard;
+                return 0;
+            }
+            ENDCG
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            Cull Off
+            ZWrite On
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normal : TEXCOORD1;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float noteno = i.uv.x * AUDIOLINK_ETOTALBINS;
+                float4 spectrum_value = -AudioLinkLerpMultiline(ALPASS_DFT + float2(noteno, 0.)) * 0.5 + 0.55;
+
+                if (i.uv.y < spectrum_value.z) discard;
+
+                float3 normalWS = normalize(i.normal);
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
+            }
+            ENDCG
+        }
+
     }
 }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo4.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo4.shader
@@ -31,16 +31,16 @@
                 float4 vertex : SV_POSITION;
                 float  corrmax : TEXCOORD2;
                 UNITY_VERTEX_OUTPUT_STEREO
-           };
+            };
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 float3 vp = v.vertex;
 
                 o.vpOrig = vp;
@@ -49,45 +49,189 @@
                 // atan2 generates a number from -pi to pi.  We want to map
                 // this from -1..1.  Tricky: add 0.001 to x otherwise
                 // we lose a vertex at the poll because atan2 is undefined.
-                float phi = atan2( vp.x+0.001, vp.z ) / 3.14159;
-                
+                float phi = atan2(vp.x + 0.001, vp.z) / 3.14159;
+
                 // We want to mirror the -1..1 so that it's actually 0..1 but
                 // mirrored.
-                float placeinautocorrelator = abs( phi );
-                
+                float placeinautocorrelator = abs(phi);
+
                 // Note: We don't need lerp multiline because the autocorrelator
                 // is only a single line.
-                float autocorrvalue = AudioLinkLerp( ALPASS_AUTOCORRELATOR +
-                    float2( placeinautocorrelator * AUDIOLINK_WIDTH, 0. ) );
-                
+                float autocorrvalue = AudioLinkLerp(ALPASS_AUTOCORRELATOR +
+                    float2(placeinautocorrelator * AUDIOLINK_WIDTH, 0.));
+
                 // Squish in the sides, and make it so it only perterbs
                 // the surface.
-                autocorrvalue = autocorrvalue * (.5-abs(vp.y)) * 0.4 + .6;
+                autocorrvalue = autocorrvalue * (.5 - abs(vp.y)) * 0.4 + .6;
 
-                // Perform same operation to find max.  The 0th bin on the 
+                // Perform same operation to find max.  The 0th bin on the
                 // autocorrelator will almost always be the max
-                o.corrmax = AudioLinkLerp( ALPASS_AUTOCORRELATOR ) * 0.2 + .6; 
+                o.corrmax = AudioLinkLerp(ALPASS_AUTOCORRELATOR) * 0.2 + .6;
 
                 // Modify the original vertices by this amount.
                 vp *= autocorrvalue;
 
-                o.vpXform = vp;                
+                o.vpXform = vp;
                 o.vertex = UnityObjectToClipPos(vp);
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
                 // Decide how we want to color from colorchord.
-                float ccplace = length( i.vpXform.xz )*2. / i.corrmax;
+                float ccplace = length(i.vpXform.xz) * 2. / i.corrmax;
 
                 // Get a color from ColorChord
-                float4 colorchordcolor = AudioLinkData( ALPASS_CCSTRIP +
-                    float2( AUDIOLINK_WIDTH * ccplace, 0. ) ) + 0.01;
+                float4 colorchordcolor = AudioLinkData(ALPASS_CCSTRIP +
+                    float2( AUDIOLINK_WIDTH * ccplace, 0. )) + 0.01;
 
                 // Shade the color a little.
-                colorchordcolor *= length( i.vpXform.xyz ) * 15. - 2.0;
+                colorchordcolor *= length(i.vpXform.xyz) * 15. - 2.0;
                 return colorchordcolor;
+            }
+            ENDCG
+        }
+
+        // DepthOnly pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                float3 vp = v.vertex;
+
+                // Generate a value for how far around the circle you are.
+                float phi = atan2(vp.x + 0.001, vp.z) / 3.14159;
+
+                // Mirror -1..1 to 0..1 mirrored
+                float placeinautocorrelator = abs(phi);
+
+                // Get autocorrelator value
+                float autocorrvalue = AudioLinkLerp(ALPASS_AUTOCORRELATOR +
+                    float2(placeinautocorrelator * AUDIOLINK_WIDTH, 0.));
+
+                // Apply deformation
+                autocorrvalue = autocorrvalue * (.5 - abs(vp.y)) * 0.4 + .6;
+
+                // Apply to vertex position
+                vp *= autocorrvalue;
+
+                o.vertex = UnityObjectToClipPos(vp);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                float3 vp = v.vertex;
+
+                // Generate a value for how far around the circle you are.
+                float phi = atan2(vp.x + 0.001, vp.z) / 3.14159;
+
+                // Mirror -1..1 to 0..1 mirrored
+                float placeinautocorrelator = abs(phi);
+
+                // Get autocorrelator value
+                float autocorrvalue = AudioLinkLerp(ALPASS_AUTOCORRELATOR +
+                    float2(placeinautocorrelator * AUDIOLINK_WIDTH, 0.));
+
+                // Apply deformation
+                autocorrvalue = autocorrvalue * (.5 - abs(vp.y)) * 0.4 + .6;
+
+                // Apply to vertex position
+                vp *= autocorrvalue;
+
+                // For a proper normal calculation, we need to adjust the normal based on the deformation
+                // This is a simplified approach - for a more accurate normal, you'd use a derivative-based approach
+                float3 normal = UnityObjectToWorldNormal(v.normal);
+
+                // Scale normal inverse to how the vertex was scaled to approximate the surface normal change
+                normal /= autocorrvalue;
+                normal = normalize(normal);
+
+                o.normal = normal;
+                o.vertex = UnityObjectToClipPos(vp);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo5.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo5.shader
@@ -14,7 +14,6 @@
             #pragma fragment frag
 
             #include "UnityCG.cginc"
-
             #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
 
             struct appdata
@@ -22,68 +21,195 @@
                 float4 vertex : POSITION;
                 float3 normal : NORMAL;
                 float2 uv : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_INPUT_INSTANCE_ID
             };
 
             struct v2f
             {
                 float3 uvw : TEXCOORD0;
-				float3 normal : TEXCOORD8;
-				float3 opos : TEXCOORD9;
+                float3 normal : TEXCOORD8;
+                float3 opos : TEXCOORD9;
                 float4 vertex : SV_POSITION;
                 UNITY_VERTEX_OUTPUT_STEREO
             };
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
-                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                    UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-            	
+
                 float3 vp = v.vertex;
 
-				// Pull out the ordinal value
-				int whichzone = floor(v.uv.x-1);
-				
-				//Only affect it if the v.uv.x was greater than or equal to 1.0
-				if( whichzone >= 0 )
-				{
-					float alpressure = AudioLinkData( ALPASS_AUDIOLINK + int2( 0, whichzone ) ).x;
-					vp.x -= alpressure * .5;
-				}
+                // Pull out the ordinal value
+                int whichzone = floor(v.uv.x - 1);
 
-				o.opos = vp;
-                o.uvw = float3( frac( v.uv ), whichzone + 0.5 );                
+                //Only affect it if the v.uv.x was greater than or equal to 1.0
+                if (whichzone >= 0)
+                {
+                    float alpressure = AudioLinkData(ALPASS_AUDIOLINK + int2( 0, whichzone )).x;
+                    vp.x -= alpressure * .5;
+                }
+
+                o.opos = vp;
+                o.uvw = float3(frac(v.uv), whichzone + 0.5);
                 o.vertex = UnityObjectToClipPos(vp);
-				o.normal = UnityObjectToWorldNormal( v.normal );
+                o.normal = UnityObjectToWorldNormal(v.normal);
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
-				float radius = length( i.uvw.xy - 0.5 ) * 30;
-				float3 color = 0;
-				if( i.uvw.z >= 0 )
-				{
-					// If a speaker, color it with a random ColorChord light.
-					color = AudioLinkLerp( ALPASS_AUDIOLINK + float2( radius, i.uvw.z ) ).rgb * 10. + 0.5;
-					
-					//Adjust the coloring on the speaker by the normal
-					color *= (dot(i.normal.xyz,float3(1,1,-1)))*.2;
-					
-					color *= AudioLinkData( ALPASS_CCLIGHTS + int2( i.uvw.z, 0) ).rgb;
-				}
-				else
-				{
-					// If the box, use the normal to color it.
-					color = abs(i.normal.xyz)*.01+.02;
-				}
-				
-                return float4( color ,1. );
+                float radius = length(i.uvw.xy - 0.5) * 30;
+                float3 color = 0;
+                if (i.uvw.z >= 0)
+                {
+                    // If a speaker, color it with a random ColorChord light.
+                    color = AudioLinkLerp(ALPASS_AUDIOLINK + float2(radius, i.uvw.z)).rgb * 10. + 0.5;
+
+                    //Adjust the coloring on the speaker by the normal
+                    color *= (dot(i.normal.xyz, float3(1, 1, -1))) * .2;
+
+                    color *= AudioLinkData(ALPASS_CCLIGHTS + int2( i.uvw.z, 0)).rgb;
+                }
+                else
+                {
+                    // If the box, use the normal to color it.
+                    color = abs(i.normal.xyz) * .01 + .02;
+                }
+
+                return float4(color, 1.);
             }
             ENDCG
         }
+
+        // DepthOnly pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                float3 vp = v.vertex;
+
+                // Pull out the ordinal value
+                int whichzone = floor(v.uv.x - 1);
+
+                // Only affect it if the v.uv.x was greater than or equal to 1.0
+                if (whichzone >= 0)
+                {
+                    float alpressure = AudioLinkData(ALPASS_AUDIOLINK + int2( 0, whichzone )).x;
+                    vp.x -= alpressure * .5;
+                }
+
+                o.vertex = UnityObjectToClipPos(vp);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                float3 vp = v.vertex;
+
+                // Pull out the ordinal value
+                int whichzone = floor(v.uv.x - 1);
+
+                // Only affect it if the v.uv.x was greater than or equal to 1.0
+                if (whichzone >= 0)
+                {
+                    float alpressure = AudioLinkData(ALPASS_AUDIOLINK + int2( 0, whichzone )).x;
+                    vp.x -= alpressure * .5;
+                }
+
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                o.vertex = UnityObjectToClipPos(vp);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
+            }
+            ENDCG
+        }
+
     }
 }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo6.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo6.shader
@@ -1,18 +1,16 @@
-﻿
-Shader "AudioLink/Examples/Demo6"
+﻿Shader "AudioLink/Examples/Demo6"
 {
     Properties
     {
-		_Logo ("Logo", 2D) = "" {}
-		_Background("Background", Color) = (0, 0, 0, 1)
+        _Logo ("Logo", 2D) = "" {}
+        _Background("Background", Color) = (0, 0, 0, 1)
     }
     SubShader
     {
 		// Allow users to make this effect transparent.
 		Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent"}
-		
-		Blend SrcAlpha OneMinusSrcAlpha 
 
+        Blend SrcAlpha OneMinusSrcAlpha
         Pass
         {
             CGPROGRAM
@@ -22,12 +20,11 @@ Shader "AudioLink/Examples/Demo6"
             #include "UnityCG.cginc"
             #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
 
-
-			uniform float4 _Background;
+            uniform float4 _Background;
             sampler2D _Logo;
             float4 _Logo_ST;
             float4 _Logo_TexelSize;
-			
+
             struct appdata
             {
                 float4 vertex : POSITION;
@@ -42,78 +39,180 @@ Shader "AudioLink/Examples/Demo6"
                 UNITY_VERTEX_OUTPUT_STEREO
             };
 
-
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
-			
 
             // Utility function to check if a point lies in the unit square.
-            float inUnit( float2 px )
+            float inUnit(float2 px)
             {
                 //0 is minimum, 1 is maximum to check
-                float2 tmp = step( 0, px ) - step( 1, px );
+                float2 tmp = step(0, px) - step(1, px);
                 return tmp.x * tmp.y;
             }
-            
-            
-            float2 hash12(float2 n){ return frac( sin(dot(n, 4.1414)) *
-				float2( 43758.5453, 38442.558 ) ); }
 
-            fixed4 frag (v2f i) : SV_Target
+            float2 hash12(float2 n)
+            {
+                return frac(sin(dot(n, 4.1414)) *
+                    float2(43758.5453, 38442.558));
+            }
+
+            fixed4 frag(v2f i) : SV_Target
             {
                 // 23 and 31 LCM of 713 cycles for same corner bounce.
-                const float2 collisiondiv = float2( 23, 31 );
+                const float2 collisiondiv = float2(23, 31);
 
                 // Make the default size of the logo take up .2 of the overall object,
                 // but let the user scale the size of their logo using the texture
                 // repeat sliders.
-                float2 logoSize = .2*_Logo_ST.xy;
-                
+                float2 logoSize = .2 * _Logo_ST.xy;
+
                 // Calculate the remaining area that the logo can bounce around.
                 float2 remainder = 1. - logoSize;
 
                 // Retrieve the instance time.
-                float instanceTime = AudioLinkDecodeDataAsSeconds( ALPASS_GENERALVU_NETWORK_TIME );
+                float instanceTime = AudioLinkDecodeDataAsSeconds(ALPASS_GENERALVU_NETWORK_TIME);
 
                 // Calculate the total progress made along X and Y irrespective of
                 // the total number of bounces made.  But then compute where the
                 // logo would have ended up after that long period of time.
                 float2 logoUV = i.uv.xy / logoSize;
-                float2 xyprogress = instanceTime * 1/collisiondiv;
-                int totalbounces = floor( xyprogress * 2. ).x + floor( xyprogress * 2. ).y;
-                float2 xyoffset = abs( frac( xyprogress ) * 2. - 1. );
+                float2 xyprogress = instanceTime * 1 / collisiondiv;
+                int totalbounces = floor(xyprogress * 2.).x + floor(xyprogress * 2.).y;
+                float2 xyoffset = abs(frac(xyprogress) * 2. - 1.);
 
                 // Update the logo position with that location.
-                logoUV -= (remainder*xyoffset)/logoSize;
+                logoUV -= (remainder * xyoffset) / logoSize;
 
                 // Read that pixel.
-                float4 logoTexel =  tex2D( _Logo, logoUV );
-                
+                float4 logoTexel = tex2D(_Logo, logoUV);
+
                 // Change the color any time it would have hit a corner.
-                float2 hash = hash12( totalbounces );
-                
+                float2 hash = hash12(totalbounces);
+
                 // Abuse the colorchord hue function here to randomly color the logo.
-                logoTexel.rgb *= AudioLinkHSVtoRGB( float3( hash.x, hash.y*0.5 + 0.5, 1. ) );
+                logoTexel.rgb *= AudioLinkHSVtoRGB(float3(hash.x, hash.y * 0.5 + 0.5, 1.));
 
                 // If we are looking for the logo where the logo is not
                 // zero it out.
-                logoTexel *= inUnit( logoUV );
+                logoTexel *= inUnit(logoUV);
 
                 // Alpha blend the logo onto the background.
-                float3 color = lerp( _Background.rgb, logoTexel.rgb, logoTexel.a ); 
-                return clamp( float4( color, _Background.a + logoTexel.a ), 0, 1 );
+                float3 color = lerp(_Background.rgb, logoTexel.rgb, logoTexel.a);
+                return clamp(float4(color, _Background.a + logoTexel.a), 0, 1);
             }
             ENDCG
         }
+
+        // DepthOnly pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                // Normalize the normal again
+                float3 normalWS = normalize(i.normal);
+
+                // Convert normal from [-1,1] to [0,1] range
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
+            }
+            ENDCG
+        }
+
     }
 }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo7.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo7.shader
@@ -42,66 +42,166 @@
             };
 
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
-            
+
             //Based on https://www.shadertoy.com/view/Mss3Wf by PauloFalcao
-            
-            float GenFractal( float2 uv, float rotqty )
+
+            float GenFractal(float2 uv, float rotqty)
             {
                 // Generate a 2x2 rotation matrix.  We can apply this in
                 // subsequent steps.
                 float2 cs;
-                sincos( rotqty, cs.x, cs.y );
-                float2x2 rotmat = float2x2( cs.x, -cs.y, cs.y, cs.x );
-
+                sincos(rotqty, cs.x, cs.y);
+                float2x2 rotmat = float2x2(cs.x, -cs.y, cs.y, cs.x);
 
                 const int maxIterations = 6;
-                float circleSize = 2.0/(3.0*pow(2.0,float(maxIterations)));
-            
-                uv = mul( rotmat, uv*.9 );
+                float circleSize = 2.0 / (3.0 * pow(2.0, float(maxIterations)));
+
+                uv = mul(rotmat, uv * .9);
                 //uv *= cs.x * 0.5 + 1.5;
-                
+
                 //mirror, rotate and scale 6 times...
-                float s= 0.3;
-                for( int i=0; i < maxIterations; i++ )
+                float s = 0.3;
+                for (int i = 0; i < maxIterations; i++)
                 {
-                    uv = abs( uv ) - s;
-                    uv = mul( rotmat, uv );
-                    s = s/2.1;
+                    uv = abs(uv) - s;
+                    uv = mul(rotmat, uv);
+                    s = s / 2.1;
                 }
 
                 float intensity = length(uv) / circleSize;
-                return 1.-intensity*.5;
+                return 1. - intensity * .5;
             }
-            
-            float4 frag (v2f i) : SV_Target
+
+            float4 frag(v2f i) : SV_Target
             {
                 uint2 quadrant = i.uv * 2;
                 int quadrant_id = quadrant.x + quadrant.y * 2;
 
                 int mode = 0;
 
-                float time = AudioLinkDecodeDataAsUInt( ALPASS_CHRONOTENSITY +
-                    uint2( mode, quadrant_id ) ) % 628318;
+                float time = AudioLinkDecodeDataAsUInt(ALPASS_CHRONOTENSITY +
+                    uint2(mode, quadrant_id)) % 628318;
 
                 float2 localuv = i.uv * 4 - quadrant * 2 - 1;
 
-                float colout = GenFractal( localuv, time/100000. );
-                
-                colout *= max( 0, AudioLinkData( ALPASS_AUDIOLINK + uint2( 0, quadrant_id ) ) - .1 );
+                float colout = GenFractal(localuv, time / 100000.);
 
-                return float4( colout.xxx, 1.);
+                colout *= max(0, AudioLinkData(ALPASS_AUDIOLINK + uint2( 0, quadrant_id )) - .1);
+
+                return float4(colout.xxx, 1.);
+            }
+            ENDCG
+        }
+
+        // DepthOnly pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                // Normalize the normal again
+                float3 normalWS = normalize(i.normal);
+
+                // Convert normal from [-1,1] to [0,1] range
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo9.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo9.shader
@@ -21,9 +21,7 @@ Shader "AudioLink/Examples/Demo9"
             #pragma fragment frag
 
             #include "UnityCG.cginc"
-
             #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
-
 
             uniform uint _AudioLinkBand;
 
@@ -42,34 +40,129 @@ Shader "AudioLink/Examples/Demo9"
             };
 
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-
-
-            float4 frag (v2f i) : SV_Target
+            float4 frag(v2f i) : SV_Target
             {
-                float2 grid_dimensions = float2(4,4);
+                float2 grid_dimensions = float2(4, 4);
                 float2 uv = i.uv * grid_dimensions;
                 uint2 grid_index = floor(uv);
-                grid_index.y = (grid_dimensions.y-1) - grid_index.y;
+                grid_index.y = (grid_dimensions.y - 1) - grid_index.y;
                 // Note: The following is a bit of a abuse of undocumented relationships between
                 // ALPASS_THEME_COLOR0
                 // ALPASS_THEME_COLOR1
                 // ALPASS_THEME_COLOR2
                 // ALPASS_THEME_COLOR3
                 return AudioLinkData(ALPASS_THEME_COLOR0 + uint2(grid_index.x, 0));
+            }
+            ENDCG
+        }
 
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                float3 normalEncoded = normalWS * 0.5 + 0.5;
+                return float4(normalEncoded, 1.0);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkExamples_ColorChordLights.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkExamples_ColorChordLights.shader
@@ -32,22 +32,117 @@
             };
 
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
-                return AudioLinkData( ALPASS_CCLIGHTS + uint2( uint( i.uv.x * 8 ) + uint(i.uv.y * 16) * 8, 0 ) ).rgba;
+                return AudioLinkData(ALPASS_CCLIGHTS + uint2( uint( i.uv.x * 8 ) + uint(i.uv.y * 16) * 8, 0 )).rgba;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                return float4(normalWS * 0.5 + 0.5, 1);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkExamples_ColorChordStrip.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkExamples_ColorChordStrip.shader
@@ -33,22 +33,117 @@
             };
 
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
-                return AudioLinkLerp( ALPASS_CCSTRIP + float2( i.uv.x * AUDIOLINK_WIDTH, 0 ) ).rgba;
+                return AudioLinkLerp(ALPASS_CCSTRIP + float2(i.uv.x * AUDIOLINK_WIDTH, 0)).rgba;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                return float4(normalWS * 0.5 + 0.5, 1);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkQuickView.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkQuickView.shader
@@ -9,6 +9,245 @@
     }
     SubShader
     {
+		Tags {"Queue" = "Transparent" "RenderType"="Opaque" }
+		AlphaToMask On
+
+        LOD 200
+        Pass
+        {
+            Blend SrcAlpha OneMinusSrcAlpha
+            ZWrite On
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 5.0
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/SmoothPixelFont.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normal : NORMAL;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            half _Glossiness;
+            half _Metallic;
+            fixed4 _Color;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                fixed4 c = 0.;
+
+                float value = 0;
+
+                float2 iuv = i.uv;
+                iuv.y = 1.-iuv.y;
+                const uint rows = 11;
+                const uint cols = 21;
+                const uint number_area_cols = 11;
+
+                float2 pos = iuv*float2(cols,rows);
+                uint2 dig = (uint2)(pos);
+
+                // Calculate softness for anti-aliasing based on derivative
+                float2 softness = 2./pow(length(float2(ddx(pos.x), ddy(pos.y))), 0.5);
+
+                float2 fmxy = float2(4, 6) - (glsl_mod(pos,1.)*float2(4.,6.));
+
+                value = 0;
+                int xoffset = 5;
+                bool leadingzero = false;
+                int points_after_decimal = 0;
+                int max_decimals = 5;
+
+                if (pos.y > 10.9)
+                {
+                    // Prevent ugly under-chart next line.
+                    c = 0;
+                }
+                else if (dig.x < cols - number_area_cols && dig.y < 8)
+                {
+                    uint sendchar = 0;
+                    const uint sendarr[80] = {
+                        'I', 'n', 's', 't', 'a', 'n', 'c', 'e', ' ', ' ',
+                        'W', 'a', 'l', 'l', 'c', 'l', 'o', 'c', 'k', ' ',
+                        'N', 'e', 't', 'w', 'o', 'r', 'k', ' ', ' ', ' ',
+                        'A', 'u', 't', 'o', ' ', 'g', 'a', 'i', 'n', ' ',
+                        'V', 'e', 'r', 's', 'i', 'o', 'n', ' ', ' ', ' ',
+                        'R', 'M', 'S', ' ', 'v', 'a', 'l', 'u', 'e', ' ',
+                        'F', 'P', 'S', ' ', 'T', '/', 'A', 'L', ' ', ' ',
+                        'P', 'l', 'a', 'y', 'e', 'r', 'I', 'n', 'f', 'o'
+                    };
+                    sendchar = sendarr[dig.x+dig.y*10];
+                    c += PrintChar(sendchar, fmxy, softness, 0.0);
+                }
+                else
+                {
+                    if (dig.y < 10)
+                        dig.x -= cols - number_area_cols;
+
+                    switch (dig.y)
+                    {
+                    case 0:
+                    case 1:
+                        // Time since level start in milliseconds.
+                        // Time of day.
+                        value = AudioLinkDecodeDataAsSeconds(dig.y?ALPASS_GENERALVU_LOCAL_TIME:ALPASS_GENERALVU_INSTANCE_TIME);
+                        float seconds = glsl_mod(value, 60);
+                        int minutes = (value/60) % 60;
+                        int hours = (value/3600);
+                        value = hours * 10000 + minutes * 100 + seconds;
+
+                        if (dig.x < 3)
+                        {
+                            value = hours;
+                            xoffset = 2;
+                            leadingzero = 1;
+                        }
+                        else if (dig.x < 5)
+                        {
+                            value = minutes;
+                            xoffset = 5;
+                            leadingzero = 1;
+                        }
+                        else if (dig.x > 5)
+                        {
+                            value = seconds;
+                            xoffset = 8;
+                            leadingzero = 1;
+                        }
+                        break;
+                    case 2:
+                        if (dig.x < 8)
+                        {
+                            value = AudioLinkDecodeDataAsUInt(ALPASS_GENERALVU_NETWORK_TIME)/1000;
+                            xoffset = 7;
+                        }
+                        else
+                        {
+                            value = AudioLinkDecodeDataAsUInt(ALPASS_GENERALVU_NETWORK_TIME)%1000;
+                            xoffset = 11;
+                            leadingzero = 1;
+                        }
+                        break;
+                    case 3:
+                        value = AudioLinkData(int2(ALPASS_GENERALVU + int2(11, 0))); //Autogain Debug
+                        break;
+                    case 4:
+                        if (dig.x < 7)
+                        {
+                            xoffset = 6;
+                            value = AudioLinkData(int2(ALPASS_GENERALVU + int2(0, 0))).g; //Version Major
+                        }
+                        else
+                        {
+                            xoffset = 8;
+                            value = AudioLinkData(int2(ALPASS_GENERALVU + int2(0, 0))).r; //Version Minor
+                        }
+                        break;
+                    case 5:
+                        value = AudioLinkData(int2(ALPASS_GENERALVU + int2(8, 0))).x; //RMS
+                        break;
+                    case 6:
+                        if (dig.x < 7)
+                        {
+                            value = AudioLinkData(int2(ALPASS_GENERALVU + int2(0, 0))).b; //True FPS
+                            xoffset = 7;
+                        }
+                        else
+                        {
+                            value = AudioLinkData(int2(ALPASS_GENERALVU + int2(1, 0))).b; //AudioLink FPS
+                            xoffset = 11;
+                        }
+                        break;
+                    case 7:
+                        if (dig.x < 3)
+                        {
+                            value = AudioLinkData(int2(ALPASS_GENERALVU_PLAYERINFO)).r;
+                            xoffset = 3;
+                        }
+                        else if (dig.x < 9)
+                        {
+                            value = AudioLinkData(int2(ALPASS_GENERALVU_PLAYERINFO)).g;
+                            xoffset = 9;
+                        }
+                        else
+                        {
+                            value = AudioLinkData(int2(ALPASS_GENERALVU_PLAYERINFO)).b;
+                            xoffset = 11;
+                        }
+                        break;
+                    case 8:
+                    case 9:
+                    case 10:
+                        if (dig.y < 10)
+                        {
+                            value = AudioLinkData(int2(ALPASS_GENERALVU + int2(7, 0)))[dig.y-8];
+                        }
+                        else
+                        {
+                            float3 wp = mul(unity_ObjectToWorld, float4(0., 0., 0., 1.));
+                            if (dig.x < 6)
+                            {
+                                value = wp.x;
+                                xoffset = 6;
+                            }
+                            else if (dig.x < 14)
+                            {
+                                value = wp.y;
+                                xoffset = 14;
+                            }
+                            else
+                            {
+                                value = wp.z;
+                                xoffset = 21;
+                            }
+                        }
+
+                        float4 amplitudemon = AudioLinkData(ALPASS_WAVEFORM + int2(iuv.x*128, 0));
+                        float2 uvin = (iuv.xy*float2(1., 11./3.)-float2(0., 8./3.));
+                        float r = amplitudemon.r + amplitudemon.a;
+                        float l = amplitudemon.r - amplitudemon.a;
+                        float comp = uvin.y * 2. - 1.;
+                        float ramp = saturate((.05 - abs(r - comp)) * 40.);
+                        float lamp = saturate((.05 - abs(l - comp)) * 40.);
+                        c.xyz += float3(1., 0.2, 0.2) * ramp + float3(.2, .2, 1.) * lamp;
+                        c.a = saturate(ramp + lamp);
+                        break;
+                    default:
+                        c = 0;
+                        break;
+                    }
+                    float num = PrintNumberOnLine(value, fmxy, softness, dig.x - xoffset, points_after_decimal, max_decimals, leadingzero, 0);
+                    c.rgb = lerp(c.rgb, 1.0, num);
+                    c.a += num;
+                }
+
+                return c;
+            }
+            ENDCG
+        }
+
         // shadow caster rendering pass, implemented manually
         // using macros from UnityCG.cginc
         Pass
@@ -21,7 +260,7 @@
             #pragma multi_compile_shadowcaster
             #include "UnityCG.cginc"
 
-            struct v2f { 
+            struct v2f {
                 V2F_SHADOW_CASTER;
             };
 
@@ -39,243 +278,100 @@
             ENDCG
         }
 
-
-
-		Tags {"Queue" = "Transparent" "RenderType"="Opaque" } 
-		AlphaToMask On
-            
-        LOD 200
-
-        CGPROGRAM
-        // Physically based Standard lighting model, and enable shadows on all light types
-        #pragma surface surf Standard fullforwardshadows alpha
-
-        #pragma target 5.0
-		
-		#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
-		#include "Packages/com.llealloo.audiolink/Runtime/Shaders/SmoothPixelFont.cginc"
-
-        sampler2D _MainTex;
-
-        struct Input
+        Pass
         {
-            float2 uv_MainTex;
-        };
+            Name "DepthOnly"
+            Tags {"LightMode" = "DepthOnly"}
 
-        half _Glossiness;
-        half _Metallic;
-        fixed4 _Color;
+            ZWrite On
+            ColorMask 0
 
-        // Add instancing support for this shader. You need to check 'Enable Instancing' on materials that use the shader.
-        // See https://docs.unity3d.com/Manual/GPUInstancing.html for more information about instancing.
-        // #pragma instancing_options assumeuniformscaling
-        UNITY_INSTANCING_BUFFER_START(Props)
-            // put more per-instance properties here
-        UNITY_INSTANCING_BUFFER_END(Props)
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 5.0
 
-        void surf (Input IN, inout SurfaceOutputStandard o)
-        {
-            fixed4 c = 0.;
-			
-			    float value = 0;
-                
-                float2 iuv =  IN.uv_MainTex;
-                iuv.y = 1.-iuv.y;
-                const uint rows = 11;
-                const uint cols = 21;
-                const uint number_area_cols = 11;
-                
-                float2 pos = iuv*float2(cols,rows);
-                uint2 dig = (uint2)(pos);
+            #include "UnityCG.cginc"
 
-                // This line of code is tricky;  We determine how much we should soften the edge of the text
-                // based on how quickly the text is moving across our field of view.  This gives us realy nice
-                // anti-aliased edges.
-                float2 softness = 2./pow( length( float2( ddx( pos.x ), ddy( pos.y ) ) ), 0.5 );
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
 
-                // Another option would be to set softness to 20 and YOLO it.
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
 
-                float2 fmxy = float2( 4, 6 ) - (glsl_mod(pos,1.)*float2(4.,6.));
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
 
-                value = 0;
-                int xoffset = 5;
-                bool leadingzero = false;
-                int points_after_decimal = 0; 
-                int max_decimals = 5;
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
+            }
 
-				if( pos.y > 10.9 ) 
-				{
-					// Prevent ugly under-chart next line.
-					c = 0;
-				}
-				else if( dig.x < cols - number_area_cols && dig.y < 8 )
-				{
-					uint sendchar = 0;
-					const uint sendarr[80] = { 
-						'I', 'n', 's', 't', 'a', 'n', 'c', 'e', ' ', ' ',
-						'W', 'a', 'l', 'l', 'c', 'l', 'o', 'c', 'k', ' ',
-						'N', 'e', 't', 'w', 'o', 'r', 'k', ' ', ' ', ' ',
-						'A', 'u', 't', 'o', ' ', 'g', 'a', 'i', 'n', ' ',
-						'V', 'e', 'r', 's', 'i', 'o', 'n', ' ', ' ', ' ',
-						'R', 'M', 'S', ' ', 'v', 'a', 'l', 'u', 'e', ' ',
-						'F', 'P', 'S', ' ', 'T', '/', 'A', 'L', ' ', ' ',
-						'P', 'l', 'a', 'y', 'e', 'r', 'I', 'n', 'f', 'o'
-						};
-					sendchar = sendarr[dig.x+dig.y*10];
-					c += PrintChar( sendchar, fmxy, softness, 0.0 );
-				}
-				else
-				{
-					if( dig.y < 10 )
-						dig.x -= cols - number_area_cols;
-
-					switch( dig.y )
-					{
-					case 0:
-					case 1:
-						// 2: Time since level start in milliseconds.
-						// 3: Time of day.
-						value = AudioLinkDecodeDataAsSeconds( dig.y?ALPASS_GENERALVU_LOCAL_TIME:ALPASS_GENERALVU_INSTANCE_TIME );
-						float seconds = glsl_mod(value, 60);
-						int minutes = (value/60) % 60;
-						int hours = (value/3600);
-						value = hours * 10000 + minutes * 100 + seconds;
-						
-						if( dig.x < 3 )
-						{
-							value = hours;
-							xoffset = 2;
-							leadingzero = 1;
-						}
-						else if( dig.x < 5 )
-						{
-							value = minutes;
-							xoffset = 5;
-							leadingzero = 1;
-						}
-						else if( dig.x > 5)
-						{
-							value = seconds;
-							xoffset = 8;
-							leadingzero = 1;
-						}
-						break;
-					case 2:
-						if( dig.x < 8 )
-						{
-							value = AudioLinkDecodeDataAsUInt( ALPASS_GENERALVU_NETWORK_TIME )/1000;
-							xoffset = 7;
-						}
-						else
-						{
-							value = AudioLinkDecodeDataAsUInt( ALPASS_GENERALVU_NETWORK_TIME )%1000;
-							xoffset = 11;
-							leadingzero = 1;
-						}
-						break;
-					case 3:
-						value = AudioLinkData( int2( ALPASS_GENERALVU + int2( 11, 0 ) ) ); //Autogain Debug
-						break;
-					case 4:
-						if( dig.x < 7 )
-						{
-							xoffset = 6;
-							value = AudioLinkData( int2( ALPASS_GENERALVU + int2( 0, 0 ) ) ).g; //Version Major
-						}
-						else
-						{
-							xoffset = 8;
-							value = AudioLinkData( int2( ALPASS_GENERALVU + int2( 0, 0 ) ) ).r; //Version Minor
-						}
-						break;
-					case 5:
-						value = AudioLinkData( int2( ALPASS_GENERALVU + int2( 8, 0 ) ) ).x; //RMS
-						break;
-
-					case 6:
-						if( dig.x < 7 )
-						{
-							value = AudioLinkData( int2( ALPASS_GENERALVU + int2( 0, 0 ) ) ).b; //True FPS
-							xoffset = 7;
-						}
-						else
-						{
-							value = AudioLinkData( int2( ALPASS_GENERALVU + int2( 1, 0 ) ) ).b; //AudioLink FPS
-							xoffset = 11;
-						}
-						break;
-
-					case 7:
-						if( dig.x < 3 )
-						{
-							value = AudioLinkData( int2( ALPASS_GENERALVU_PLAYERINFO ) ).r;
-							xoffset = 3;
-						}
-						else if( dig.x < 9 )
-						{
-							value = AudioLinkData( int2( ALPASS_GENERALVU_PLAYERINFO ) ).g;
-							xoffset = 9;
-						}
-						else
-						{
-							value = AudioLinkData( int2( ALPASS_GENERALVU_PLAYERINFO ) ).b;
-							xoffset = 11;
-						}
-						break;
-					case 8:
-					case 9:
-					case 10:
-						if( dig.y < 10 )
-						{
-							value = AudioLinkData( int2( ALPASS_GENERALVU + int2(7, 0 ) ) )[dig.y-8];
-						}
-						else
-						{
-							float3 wp = mul( unity_ObjectToWorld, float4( 0., 0., 0., 1. ) );
-							if( dig.x < 6 )
-							{
-								value = wp.x;
-								xoffset = 6;
-							}
-							else if( dig.x < 14 )
-							{
-								value = wp.y;
-								xoffset = 14;
-							}
-							else
-							{
-								value = wp.z;
-								xoffset = 21;
-							}
-						}
-						
-						float4 amplitudemon = AudioLinkData( ALPASS_WAVEFORM + int2( iuv.x*128, 0 ) );
-						float2 uvin = ( iuv.xy*float2(1., 11./3.)-float2( 0., 8./3.) );
-						float r = amplitudemon.r + amplitudemon.a;
-						float l = amplitudemon.r - amplitudemon.a;
-						float comp = uvin.y * 2. - 1.;
-						float ramp = saturate( (.05 - abs( r - comp )) * 40. );
-						float lamp = saturate( (.05 - abs( l - comp )) * 40. );
-						c.xyz += float3( 1., 0.2, 0.2 ) * ramp + float3( .2, .2, 1. ) * lamp;
-						c.a = saturate(ramp + lamp);
-						break;
-					default:
-						c = 0;
-						break;
-					}
-					float num = PrintNumberOnLine( value, fmxy, softness, dig.x - xoffset, points_after_decimal, max_decimals, leadingzero, 0 );
-					c.rgb = lerp( c.rgb, 1.0, num );
-					c.a += num;
-				}
-            o.Emission = c.rgb;
-			o.Albedo = c.rgb;
-
-            // Metallic and smoothness come from slider variables
-            o.Metallic = _Metallic;
-            o.Smoothness = _Glossiness;
-            o.Alpha = c.a;
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
         }
-        ENDCG
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags {"LightMode" = "DepthNormals"}
+
+            ZWrite On
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 5.0
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normal : NORMAL;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normal : TEXCOORD1;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normal = normalize(i.normal);
+                float2 encodedNormal = normalize(normal.xy) * sqrt(normal.z * 0.5 + 0.5);
+                encodedNormal = encodedNormal * 0.5 + 0.5;
+                return float4(encodedNormal, 0, 0);
+            }
+            ENDCG
+        }
     }
     FallBack "Diffuse"
 }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkStandardLit.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkStandardLit.shader
@@ -1,0 +1,686 @@
+Shader "AudioLink/StandardLit"
+{
+    Properties
+    {
+        // URP
+
+        // Specular vs Metallic workflow
+        _WorkflowMode("WorkflowMode", Float) = 1.0
+
+        [MainTexture] _BaseMap("Albedo", 2D) = "white" {}
+        [MainColor] _BaseColor("Color", Color) = (1,1,1,1)
+
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+
+        _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5
+        _SmoothnessTextureChannel("Smoothness texture channel", Float) = 0
+
+        _Metallic("Metallic", Range(0.0, 1.0)) = 0.0
+        _MetallicGlossMap("Metallic", 2D) = "white" {}
+
+        _SpecColor("Specular", Color) = (0.2, 0.2, 0.2)
+        _SpecGlossMap("Specular", 2D) = "white" {}
+
+        [ToggleOff] _SpecularHighlights("Specular Highlights", Float) = 1.0
+        [ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
+
+        _BumpScale("Scale", Float) = 1.0
+        _BumpMap("Normal Map", 2D) = "bump" {}
+
+        _Parallax("Scale", Range(0.005, 0.08)) = 0.005
+        _ParallaxMap("Height Map", 2D) = "black" {}
+
+        _OcclusionStrength("Strength", Range(0.0, 1.0)) = 1.0
+        _OcclusionMap("Occlusion", 2D) = "white" {}
+
+        [HDR] _EmissionColor("Color", Color) = (0,0,0)
+        _EmissionMap("Emission", 2D) = "white" {}
+
+        _DetailMask("Detail Mask", 2D) = "white" {}
+        _DetailAlbedoMapScale("Scale", Range(0.0, 2.0)) = 1.0
+        _DetailAlbedoMap("Detail Albedo x2", 2D) = "linearGrey" {}
+        _DetailNormalMapScale("Scale", Range(0.0, 2.0)) = 1.0
+        [Normal] _DetailNormalMap("Normal Map", 2D) = "bump" {}
+
+        // SRP batching compatibility for Clear Coat (Not used in Lit)
+        [HideInInspector] _ClearCoatMask("_ClearCoatMask", Float) = 0.0
+        [HideInInspector] _ClearCoatSmoothness("_ClearCoatSmoothness", Float) = 0.0
+
+        // Blending state
+        _Surface("__surface", Float) = 0.0
+        _Blend("__blend", Float) = 0.0
+        _Cull("__cull", Float) = 2.0
+        [ToggleUI] _AlphaClip("__clip", Float) = 0.0
+        [HideInInspector] _SrcBlend("__src", Float) = 1.0
+        [HideInInspector] _DstBlend("__dst", Float) = 0.0
+        [HideInInspector] _SrcBlendAlpha("__srcA", Float) = 1.0
+        [HideInInspector] _DstBlendAlpha("__dstA", Float) = 0.0
+        [HideInInspector] _ZWrite("__zw", Float) = 1.0
+        [HideInInspector] _BlendModePreserveSpecular("_BlendModePreserveSpecular", Float) = 1.0
+        [HideInInspector] _AlphaToMask("__alphaToMask", Float) = 0.0
+        [HideInInspector] _AddPrecomputedVelocity("_AddPrecomputedVelocity", Float) = 0.0
+
+        [ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
+        // Editmode props
+        _QueueOffset("Queue offset", Float) = 0.0
+
+        // ObsoleteProperties
+        [HideInInspector] _MainTex("BaseMap", 2D) = "white" {}
+        [HideInInspector] _Color("Base Color", Color) = (1, 1, 1, 1)
+        [HideInInspector] _GlossMapScale("Smoothness", Float) = 0.0
+        [HideInInspector] _Glossiness("Smoothness", Float) = 0.0
+        [HideInInspector] _GlossyReflections("EnvironmentReflections", Float) = 0.0
+
+        [HideInInspector][NoScaleOffset]unity_Lightmaps("unity_Lightmaps", 2DArray) = "" {}
+        [HideInInspector][NoScaleOffset]unity_LightmapsInd("unity_LightmapsInd", 2DArray) = "" {}
+        [HideInInspector][NoScaleOffset]unity_ShadowMasks("unity_ShadowMasks", 2DArray) = "" {}
+
+        // BIRP specific
+        [Enum(UV0,0,UV1,1)] _UVSec ("UV Set for secondary textures", Float) = 0
+        // Blending state
+        [HideInInspector] _Mode ("__mode", Float) = 0.0
+    }
+
+    // URP Lit
+    SubShader
+    {
+        // Universal Pipeline tag is required. If Universal render pipeline is not set in the graphics settings
+        // this Subshader will fail. One can add a subshader below or fallback to Standard built-in to make this
+        // material work with both Universal Render Pipeline and Builtin Unity Pipeline
+        PackageRequirements{ "com.unity.render-pipelines.universal" }
+        Tags
+        {
+            "RenderType" = "Opaque"
+            "RenderPipeline" = "UniversalPipeline"
+            "UniversalMaterialType" = "Lit"
+            "IgnoreProjector" = "True"
+        }
+        LOD 300
+
+        // ------------------------------------------------------------------
+        //  Forward pass. Shades all light in a single pass. GI + emission + Fog
+        Pass
+        {
+            // Lightmode matches the ShaderPassName set in UniversalRenderPipeline.cs. SRPDefaultUnlit and passes with
+            // no LightMode tag are also rendered by Universal Render Pipeline
+            Name "ForwardLit"
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            Blend[_SrcBlend][_DstBlend], [_SrcBlendAlpha][_DstBlendAlpha]
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+            AlphaToMask[_AlphaToMask]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex LitPassVertex
+            #pragma fragment LitPassFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local _PARALLAXMAP
+            #pragma shader_feature_local _RECEIVE_SHADOWS_OFF
+            #pragma shader_feature_local _ _DETAIL_MULX2 _DETAIL_SCALED
+            #pragma shader_feature_local_fragment _SURFACE_TYPE_TRANSPARENT
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ _ALPHAPREMULTIPLY_ON _ALPHAMODULATE_ON
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local_fragment _METALLICSPECGLOSSMAP
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+            #pragma shader_feature_local_fragment _OCCLUSIONMAP
+            #pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+            #pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+            #pragma shader_feature_local_fragment _SPECULAR_SETUP
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ EVALUATE_SH_MIXED EVALUATE_SH_VERTEX
+            #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _REFLECTION_PROBE_BLENDING
+            #pragma multi_compile_fragment _ _REFLECTION_PROBE_BOX_PROJECTION
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT _SHADOWS_SOFT_LOW _SHADOWS_SOFT_MEDIUM _SHADOWS_SOFT_HIGH
+            #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile_fragment _ _LIGHT_COOKIES
+            #pragma multi_compile _ _LIGHT_LAYERS
+            #pragma multi_compile _ _FORWARD_PLUS
+
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+            #pragma multi_compile _ SHADOWS_SHADOWMASK
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
+            #pragma multi_compile _ USE_LEGACY_LIGHTMAPS
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #pragma multi_compile_fragment _ DEBUG_DISPLAY
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma instancing_options renderinglayer
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl"
+            #else// Minimal vertex function
+            // #pragma vert Vertex
+            // #pragma frag Fragment
+            float4 LitPassVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 LitPassFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags
+            {
+                "LightMode" = "ShadowCaster"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex ShadowPassVertex
+            #pragma fragment ShadowPassFragment
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            // This is used during shadow map generation to differentiate between directional and punctual light shadows, as they use different formulas to apply Normal Bias
+            #pragma multi_compile_vertex _ _CASTING_PUNCTUAL_LIGHT_SHADOW
+
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/ShadowCasterPass.hlsl"
+            #else
+            // #pragma vert Vertex
+            // #pragma frag Fragment
+            float4 ShadowPassVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 ShadowPassFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            // Lightmode matches the ShaderPassName set in UniversalRenderPipeline.cs. SRPDefaultUnlit and passes with
+            // no LightMode tag are also rendered by Universal Render Pipeline
+            Name "GBuffer"
+            Tags
+            {
+                "LightMode" = "UniversalGBuffer"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite[_ZWrite]
+            ZTest LEqual
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 4.5
+
+            // Deferred Rendering Path does not support the OpenGL-based graphics API:
+            // Desktop OpenGL, OpenGL ES 3.0, WebGL 2.0.
+            #pragma exclude_renderers gles3 glcore
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex LitGBufferPassVertex
+            #pragma fragment LitGBufferPassFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            //#pragma shader_feature_local_fragment _ALPHAPREMULTIPLY_ON
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local_fragment _METALLICSPECGLOSSMAP
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+            #pragma shader_feature_local_fragment _OCCLUSIONMAP
+            #pragma shader_feature_local _PARALLAXMAP
+            #pragma shader_feature_local _ _DETAIL_MULX2 _DETAIL_SCALED
+
+            #pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+            #pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+            #pragma shader_feature_local_fragment _SPECULAR_SETUP
+            #pragma shader_feature_local _RECEIVE_SHADOWS_OFF
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            //#pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            //#pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _REFLECTION_PROBE_BLENDING
+            #pragma multi_compile_fragment _ _REFLECTION_PROBE_BOX_PROJECTION
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT _SHADOWS_SOFT_LOW _SHADOWS_SOFT_MEDIUM _SHADOWS_SOFT_HIGH
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile_fragment _ _RENDER_PASS_ENABLED
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+            #pragma multi_compile _ SHADOWS_SHADOWMASK
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
+            #pragma multi_compile _ USE_LEGACY_LIGHTMAPS
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fragment _ _GBUFFER_NORMALS_OCT
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma instancing_options renderinglayer
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitGBufferPass.hlsl"
+            #else
+            // #pragma vert Vertex
+            // #pragma frag Fragment
+            float4 LitGBufferPassVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 LitGBufferPassFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+            ColorMask R
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex DepthOnlyVertex
+            #pragma fragment DepthOnlyFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthOnlyPass.hlsl"
+            #else
+            // #pragma vert Vertex
+            // #pragma frag Fragment
+            float4 DepthOnlyVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 DepthOnlyFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        // This pass is used when drawing to a _CameraNormalsTexture texture
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex DepthNormalsVertex
+            #pragma fragment DepthNormalsFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local _PARALLAXMAP
+            #pragma shader_feature_local _ _DETAIL_MULX2 _DETAIL_SCALED
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitDepthNormalsPass.hlsl"
+            #else
+            float4 DepthNormalsVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 DepthNormalsFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        // This pass it not used during regular rendering, only for lightmap baking.
+        Pass
+        {
+            Name "Meta"
+            Tags
+            {
+                "LightMode" = "Meta"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex UniversalVertexMeta
+            #pragma fragment UniversalFragmentMetaLit
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _SPECULAR_SETUP
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local_fragment _METALLICSPECGLOSSMAP
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+            #pragma shader_feature_local _ _DETAIL_MULX2 _DETAIL_SCALED
+            #pragma shader_feature_local_fragment _SPECGLOSSMAP
+            #pragma shader_feature EDITOR_VISUALIZATION
+
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitMetaPass.hlsl"
+            #else
+            float4 UniversalVertexMeta(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 UniversalFragmentMetaLit() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "Universal2D"
+            Tags
+            {
+                "LightMode" = "Universal2D"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            Blend[_SrcBlend][_DstBlend]
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex vert
+            #pragma fragment frag
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ALPHAPREMULTIPLY_ON
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/Utils/Universal2D.hlsl"
+            #else
+            #pragma vert Vertex
+            #pragma frag Fragment
+            float4 Vertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 Fragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "MotionVectors"
+            Tags
+            {
+                "LightMode" = "MotionVectors"
+            }
+            ColorMask RG
+
+            HLSLPROGRAM
+            // #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
+            #else
+            #pragma vert Vertex
+            #pragma frag Fragment
+            float4 Vertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 Fragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "XRMotionVectors"
+            Tags
+            {
+                "LightMode" = "XRMotionVectors"
+            }
+            ColorMask RGBA
+
+            // Stencil write for obj motion pixels
+            Stencil
+            {
+                WriteMask 1
+                Ref 1
+                Comp Always
+                Pass Replace
+            }
+
+            HLSLPROGRAM
+            // #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+            #define APLICATION_SPACE_WARP_MOTION 1
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
+            #else
+            #pragma vert Vertex
+            #pragma frag Fragment
+            float4 Vertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 Fragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+    }
+
+    // Fallback to Standard shader for Built-in Render Pipeline
+    FallBack "Standard"
+    CustomEditor "VRSL.Shaders.VRSLStandardInspector"
+}

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkStandardLit.shader.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkStandardLit.shader.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f00b5b7bf3b4b204691945f5eba97a16
+timeCreated: 1747358215

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkTestLights.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkTestLights.shader
@@ -33,7 +33,7 @@
                 UNITY_FOG_COORDS(1)
                 UNITY_VERTEX_OUTPUT_STEREO
             };
-			
+
             v2f vert (appdata v)
             {
                 v2f o;
@@ -41,7 +41,7 @@
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 UNITY_TRANSFER_FOG(o,o.vertex);
@@ -54,6 +54,95 @@
 				float4 finalColor = AudioLinkData( int2( ALPASS_CCLIGHTS + int2( lampno, 0 ) ) );
 				UNITY_APPLY_FOG(i.fogCoord, finalColor);
 				return finalColor;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags{"LightMode" = "DepthOnly"}
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags{"LightMode" = "DepthNormals"}
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                return float4(normalWS * 0.5 + 0.5, 1);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkTestTime.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkTestTime.shader
@@ -34,30 +34,30 @@
             };
 
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-            float4 frag (v2f i) : SV_Target
+            float4 frag(v2f i) : SV_Target
             {
                 float value = 0;
-                
+
                 float2 iuv = i.uv;
-                iuv.y = 1.-iuv.y;
+                iuv.y = 1. - iuv.y;
                 const uint rows = 21;
                 const uint cols = 21;
                 const uint number_area_cols = 11;
-                
-                float2 pos = iuv*float2(cols,rows);
+
+                float2 pos = iuv * float2(cols, rows);
                 uint2 dig = (uint2)(pos);
 
                 // This line of code is tricky;  We determine how much we should soften the edge of the text
@@ -67,12 +67,12 @@
 
                 // Another option would be to set softness to 20 and YOLO it.
 
-                float2 fmxy = float2( 4, 6 ) - (glsl_mod(pos,1.)*float2(4.,6.));
+                float2 fmxy = float2(4, 6) - (glsl_mod(pos, 1.) * float2(4., 6.));
 
                 value = 0;
                 int xoffset = 5;
                 bool leadingzero = false;
-                int points_after_decimal = 0; 
+                int points_after_decimal = 0;
                 int max_decimals = 6;
 
                 if( dig.y < 13 )
@@ -99,6 +99,7 @@
                         return PrintChar( sendchar, fmxy, softness, 0.0 );
                     }
                     
+
                     dig.x -= cols - number_area_cols;
                 }
                 else
@@ -248,6 +249,97 @@
                 }
 
                 return PrintNumberOnLine( value, fmxy, softness, dig.x - xoffset, points_after_decimal, max_decimals, leadingzero, 0 );         
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                return float4(normalWS * 0.5 + 0.5, 1);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUI-Functions.cginc
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUI-Functions.cginc
@@ -1,0 +1,711 @@
+#ifndef AUDIOLINK_UI_FUNCTIONS
+#define AUDIOLINK_UI_FUNCTIONS
+
+#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+// Uniforms
+float _Power;
+float _Gain;
+float _AutoGain;
+float _Threshold0;
+float _Threshold1;
+float _Threshold2;
+float _Threshold3;
+float _X0;
+float _X1;
+float _X2;
+float _X3;
+float _HitFade;
+float _ExpFalloff;
+uint _ThemeColorMode;
+uint _SelectedColor;
+float _Hue;
+float _Saturation;
+float _Value;
+float3 _CustomColor0;
+float3 _CustomColor1;
+float3 _CustomColor2;
+float3 _CustomColor3;
+sampler2D _GainTexture;
+float4 _GainTexture_TexelSize;
+sampler2D _AutoGainTexture;
+float4 _AutoGainTexture_TexelSize;
+sampler2D _PowerTexture;
+float4 _PowerTexture_TexelSize;
+sampler2D _ResetTexture;
+float4 _ResetTexture_TexelSize;
+
+// Colors
+const static float3 BACKGROUND_COLOR = 0.033;
+const static float3 FOREGROUND_COLOR = 0.075;
+const static float3 INACTIVE_COLOR = 0.13;
+const static float3 ACTIVE_COLOR = 0.8;
+const static float3 BASS_COLOR_BG = pow(float3(44.0 / 255.0, 12.0 / 255.0, 43.0 / 255.0), 2.2);
+const static float3 BASS_COLOR_MG = pow(float3(103.0 / 255.0, 27.0 / 255.0, 100.0 / 255.0), 2.2);
+const static float3 BASS_COLOR_FG = pow(float3(147.0 / 255.0, 39.0 / 255.0, 143.0 / 255.0), 2.2);
+const static float3 LOWMID_COLOR_BG = pow(float3(76.0 / 255.0, 53.0 / 255.0, 18.0 / 255.0), 2.2);
+const static float3 HIGHMID_COLOR_BG = pow(float3(42.0 / 255.0, 60.0 / 255.0, 19.0 / 255.0), 2.2);
+const static float3 HIGH_COLOR_BG = pow(float3(12.0 / 255.0, 52.0 / 255.0, 68.0 / 255.0), 2.2);
+const static float3 HIGH_COLOR_FG = pow(float3(41.0 / 255.0, 171.0 / 255.0, 226.0 / 255.0), 2.2);
+
+// Spacing
+const static float CORNER_RADIUS = 0.025;
+const static float FRAME_MARGIN = 0.03;
+const static float HANDLE_RADIUS = 0.007;
+const static float OUTLINE_WIDTH = 0.002;
+
+#define remap(value, low1, high1, low2, high2) ((low2) + ((value) - (low1)) * ((high2) - (low2)) / ((high1) - (low1)))
+
+#define COHERENT_CONDITION(condition) ((condition) || any(fwidth(condition)))
+#define ADD_ELEMENT(existing, elementColor, elementDist) [branch] if (COHERENT_CONDITION(elementDist <= 0.01)) addElement(existing, elementColor, elementDist)
+
+float3 selectColor(uint i, float3 a, float3 b, float3 c, float3 d)
+{
+    return float4x4(
+        float4(a, 0.0),
+        float4(b, 0.0),
+        float4(c, 0.0),
+        float4(d, 0.0)
+    )[i % 4];
+}
+
+float3 selectColorLerp(float i, float3 a, float3 b, float3 c, float3 d)
+{
+    int me = floor(i);
+    float3 meColor = selectColor(me, a, b, c, d);
+
+    // avoid singularity at 0.5
+    if (COHERENT_CONDITION(distance(frac(i), 0.5) < 0.1))
+        return meColor;
+
+    int side = sign(frac(i) - 0.5);
+    int other = clamp(me + side, 0, 3);
+
+    float3 otherColor = selectColor(other, a, b, c, d);
+
+    float dist = round(i) - i;
+    const float pixelDiagonal = sqrt(2.0) / 2.0 * side;
+    float distDerivativeLength = sqrt(pow(ddx(dist), 2) + pow(ddy(dist), 2));
+
+    return lerp(otherColor, meColor, smoothstep(-pixelDiagonal, pixelDiagonal, dist / distDerivativeLength));
+}
+
+float3 getBandColor(uint i) { return selectColor(i, BASS_COLOR_BG, LOWMID_COLOR_BG, HIGHMID_COLOR_BG, HIGH_COLOR_BG); }
+
+float3 getBandColorLerp(float i)
+{
+    return selectColorLerp(i, BASS_COLOR_BG, LOWMID_COLOR_BG, HIGHMID_COLOR_BG, HIGH_COLOR_BG);
+}
+
+// TODO: Deduplicate this
+float3 getBandAmplitudeLerp(float i, float delay)
+{
+    int me = floor(i);
+    float meStrength = AudioLinkLerp(float2(delay, me)).r;
+
+    // avoid singularity at 0.5
+    if (COHERENT_CONDITION(distance(frac(i), 0.5) < 0.1))
+        return meStrength;
+
+    int side = sign(frac(i) - 0.5);
+    int other = clamp(me + side, 0, 3);
+
+    float otherStrength = AudioLinkLerp(float2(delay, other)).r;
+
+    float dist = round(i) - i;
+    const float pixelDiagonal = sqrt(2.0) / 2.0 * side;
+    float distDerivativeLength = sqrt(pow(ddx(dist), 2) + pow(ddy(dist), 2));
+
+    return lerp(otherStrength, meStrength, smoothstep(-pixelDiagonal, pixelDiagonal, dist / distDerivativeLength));
+}
+
+float2x2 rotationMatrix(float angle)
+{
+    return float2x2(
+        float2(cos(angle), -sin(angle)),
+        float2(sin(angle), cos(angle))
+    );
+}
+
+float2 translate(float2 p, float2 offset)
+{
+    return p - offset;
+}
+
+float2 rotate(float2 p, float angle)
+{
+    return mul(rotationMatrix(angle), p);
+}
+
+float shell(float d, float thickness)
+{
+    return abs(d) - thickness;
+}
+
+float inflate(float d, float thickness)
+{
+    return d - thickness;
+}
+
+float lerpstep(float a, float b, float x)
+{
+    return saturate((x - a) / (b - a));
+}
+
+void addElement(inout float3 existing, float3 elementColor, float elementDist)
+{
+    const float pixelDiagonal = sqrt(2.0) / 2.0;
+    float distDerivativeLength = sqrt(pow(ddx(elementDist), 2) + pow(ddy(elementDist), 2));
+    existing = lerp(elementColor, existing,
+                    lerpstep(-pixelDiagonal, pixelDiagonal, elementDist / distDerivativeLength));
+}
+
+float sdRoundedBoxCentered(float2 p, float2 b, float4 r)
+{
+    r.xy = (p.x > 0.0) ? r.xy : r.zw;
+    r.x = (p.y > 0.0) ? r.x : r.y;
+    float2 q = abs(p) - b * 0.5 + r.x;
+    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r.x;
+}
+
+float sdRoundedBoxTopLeft(float2 p, float2 b, float4 r)
+{
+    return sdRoundedBoxCentered(translate(p, b * 0.5), b, r);
+}
+
+float sdRoundedBoxBottomRight(float2 p, float2 b, float4 r)
+{
+    return sdRoundedBoxCentered(translate(p, float2(b.x, -b.y) * 0.5), b, r);
+}
+
+float sdSphere(float2 p, float r)
+{
+    return length(p) - r;
+}
+
+float sdTriangleIsosceles(float2 p, float2 q)
+{
+    p.x = abs(p.x);
+    float2 a = p - q * clamp(dot(p, q) / dot(q, q), 0.0, 1.0);
+    float2 b = p - q * float2(clamp(p.x / q.x, 0.0, 1.0), 1.0);
+    float s = -sign(q.y);
+    float2 d = min(float2(dot(a, a), s * (p.x * q.y - p.y * q.x)),
+                   float2(dot(b, b), s * (p.y - q.y)));
+    return -sqrt(d.x) * sign(d.y);
+}
+
+float sdTriangleRight(float2 p, float halfWidth, float halfHeight)
+{
+    float2 end = float2(halfWidth, -halfHeight);
+    float2 d = p - end * clamp(dot(p, end) / dot(end, end), -1.0, 1.0);
+    if (max(d.x, d.y) > 0.0)
+    {
+        return length(d);
+    }
+    p += float2(halfWidth, halfHeight);
+    if (max(p.x, p.y) > 0.0)
+    {
+        return -min(length(d), min(p.x, p.y));
+    }
+    return length(p);
+}
+
+float sdSegment(float2 p, float2 a, float2 b)
+{
+    float2 pa = p - a, ba = b - a;
+    float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+    return length(pa - ba * h);
+}
+
+#define TEX2D_MSDF(tex, uv) tex2DMSDF(tex, tex##_TexelSize.xy * 4.0, uv)
+
+float tex2DMSDF(sampler2D tex, float2 unit, float2 uv)
+{
+    float3 c = tex2D(tex, uv).rgb;
+    return saturate(
+        (max(min(c.r, c.g), min(max(c.r, c.g), c.b)) - 0.5) *
+        max(dot(unit, 0.5 / fwidth(uv)), 1) + 0.5
+    );
+}
+
+float3 drawTopArea(float2 uv)
+{
+    float3 color = FOREGROUND_COLOR;
+
+    float areaWidth = 1.0 - FRAME_MARGIN * 2;
+    float areaHeight = 0.35;
+    float handleWidth = 0.015 * areaWidth;
+
+    float threshold[4] = {_Threshold0, _Threshold1, _Threshold2, _Threshold3};
+    float crossover[4] = {_X0 * areaWidth, _X1 * areaWidth, _X2 * areaWidth, _X3 * areaWidth};
+
+    // prefix sum to calculate offsets and sizes for boxes
+    uint start = 0;
+    uint stop = 4;
+    float currentBoxOffset = crossover[start];
+    float boxOffsets[4] = {0, 0, 0, 0};
+    float boxWidths[4] = {0, 0, 0, 0};
+    for (uint i = 0; i < 4; i++)
+    {
+        float boxWidth = 0.0;
+        if (i == 3) // The last box should just stretch to fill
+            boxWidth = areaWidth - currentBoxOffset;
+        else
+            boxWidth = crossover[i + 1] - crossover[i];
+
+        boxOffsets[i] = currentBoxOffset;
+        boxWidths[i] = boxWidth;
+
+        // Keep track of the range of boxes we need to draw
+        if (COHERENT_CONDITION(uv.x > currentBoxOffset + OUTLINE_WIDTH))
+            start = i;
+        if (COHERENT_CONDITION(uv.x < currentBoxOffset + boxWidth - handleWidth))
+            stop = min(stop, i + 1);
+
+        currentBoxOffset += boxWidth;
+    }
+
+    // waveform calculation
+    uint totalBins = AUDIOLINK_EXPBINS * AUDIOLINK_EXPOCT;
+    uint noteno = AudioLinkRemap(uv.x, 0., 1., AUDIOLINK_4BAND_FREQFLOOR * totalBins,
+                                 AUDIOLINK_4BAND_FREQCEILING * totalBins);
+    float notenof = AudioLinkRemap(uv.x, 0., 1., AUDIOLINK_4BAND_FREQFLOOR * totalBins,
+                                   AUDIOLINK_4BAND_FREQCEILING * totalBins);
+    float4 specLow = AudioLinkData(float2(fmod(noteno, 128), (noteno / 128) + 4.0));
+    float4 specHigh = AudioLinkData(float2(fmod(noteno + 1, 128), ((noteno + 1) / 128) + 4.0));
+    float4 intensity = lerp(specLow, specHigh, frac(notenof)) * _Gain;
+    float bandIntensity = AudioLinkData(float2(0., start ^ 0)); // XOR with 0 to avoid FXC miscompilation
+    float funcY = areaHeight - (intensity.g * areaHeight);
+    float waveformDist = smoothstep(0.005, 0.003, funcY - uv.y);
+    float waveformDistAbs = abs(smoothstep(0.005, 0.003, abs(funcY - uv.y)));
+
+    // background waveform
+    color = lerp(color, color * 2, waveformDist);
+    color = lerp(color, color * 2, waveformDistAbs);
+
+    // This optimization increases performance, but introduces aliasing. The perf difference is only really noticeable on Quest.
+    #if defined(UNITY_PBS_USE_BRDF2) || defined(SHADER_API_MOBILE)
+                [loop] for (uint i = start; i < min(stop, 4); i++)
+    #else
+    for (uint i = 0; i < 4; i++)
+    #endif
+    {
+        float boxHeight = threshold[i] * areaHeight;
+        float boxWidth = boxWidths[i];
+        float boxOffset = boxOffsets[i];
+
+        float leftCornerRadius = i == 0 ? CORNER_RADIUS : 0.0;
+        float rightCornerRadius = i == 3 ? CORNER_RADIUS : 0.0;
+        float boxDist = sdRoundedBoxBottomRight(
+            translate(uv, float2(boxOffset, areaHeight)),
+            float2(boxWidth, boxHeight),
+            float4(rightCornerRadius, CORNER_RADIUS, leftCornerRadius, CORNER_RADIUS)
+        );
+
+        // colored inner portion
+        float3 innerColor = getBandColor(i);
+        innerColor = lerp(innerColor, innerColor * 3, waveformDist);
+        innerColor = lerp(innerColor, lerp(innerColor * 3, 1.0, bandIntensity > threshold[i]), waveformDistAbs);
+        ADD_ELEMENT(color, innerColor, boxDist+OUTLINE_WIDTH);
+
+        // outer shell
+        float shellDist = shell(boxDist, OUTLINE_WIDTH);
+        ADD_ELEMENT(color, ACTIVE_COLOR, shellDist);
+
+        // Top pivot
+        float handleDist = sdSphere(
+            translate(uv, float2(boxWidth * 0.5 + boxOffset, areaHeight - boxHeight)),
+            HANDLE_RADIUS
+        );
+        ADD_ELEMENT(color, 1.0, handleDist);
+
+        // Side pivot
+        handleDist = sdRoundedBoxCentered(
+            translate(uv, float2(boxOffset, areaHeight - boxHeight * 0.5)),
+            float2(handleWidth, 0.35 * boxHeight),
+            HANDLE_RADIUS
+        );
+        ADD_ELEMENT(color, 1.0, handleDist);
+    }
+
+    return color;
+}
+
+float3 drawGainArea(float2 uv, float2 size)
+{
+    float3 inactiveColor = INACTIVE_COLOR;
+    float3 activeColor = ACTIVE_COLOR;
+    float3 t = _Gain / 2.0f;
+
+    float3 color = FOREGROUND_COLOR;
+
+    float gainIcon = TEX2D_MSDF(_GainTexture, saturate((uv - float2(0.01, 0.0)) / size.y));
+    color = lerp(color, ACTIVE_COLOR, gainIcon.r);
+
+    const float sliderOffsetLeft = 0.16;
+    const float sliderOffsetRight = 0.02;
+
+    // Background fill
+    float maxTriangleWidth = size.x - sliderOffsetLeft - sliderOffsetRight;
+    float bgTriangleDist = inflate(sdTriangleIsosceles(
+                                       rotate(translate(uv, float2(sliderOffsetLeft, size.y * 0.5)), UNITY_PI * 0.5),
+                                       float2(size.y * 0.3, maxTriangleWidth)
+                                   ), 0.002);
+    ADD_ELEMENT(color, inactiveColor, bgTriangleDist);
+
+    // Current active area
+    float currentTriangleWidth = maxTriangleWidth * t;
+    float currentTriangleDist = max(bgTriangleDist, uv.x - currentTriangleWidth - sliderOffsetLeft);
+    ADD_ELEMENT(color, activeColor, currentTriangleDist);
+
+    // Slider handle
+    float handleDist = sdSphere(
+        translate(uv, float2(currentTriangleWidth + sliderOffsetLeft, size.y * 0.5)),
+        HANDLE_RADIUS
+    );
+    ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
+
+    // Slider vertical grip
+    float gripDist = abs(uv.x - currentTriangleWidth - sliderOffsetLeft) - OUTLINE_WIDTH;
+    ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
+
+    return color;
+}
+
+float drawAutoGainButton(float2 uv, float2 size)
+{
+    float2 scaledUV = uv / size;
+    float autoGainIcon = TEX2D_MSDF(_AutoGainTexture, float2(scaledUV.x, 1-scaledUV.y));
+    return lerp(FOREGROUND_COLOR, _AutoGain ? ACTIVE_COLOR : INACTIVE_COLOR, autoGainIcon);
+}
+
+float drawPowerButton(float2 uv, float2 size)
+{
+    float2 scaledUV = uv / size;
+    float powerIcon = TEX2D_MSDF(_PowerTexture, float2(scaledUV.x, 1-scaledUV.y));
+    return lerp(FOREGROUND_COLOR, _Power ? ACTIVE_COLOR : INACTIVE_COLOR, powerIcon);
+}
+
+float drawResetButton(float2 uv, float2 size)
+{
+    float2 scaledUV = uv / size;
+    float resetIcon = TEX2D_MSDF(_ResetTexture, float2(scaledUV.x, 1-scaledUV.y));
+    return lerp(FOREGROUND_COLOR, ACTIVE_COLOR, resetIcon);
+}
+
+float3 drawHitFadeArea(float2 uv, float2 size)
+{
+    float3 color = FOREGROUND_COLOR;
+
+    // Background fill
+    float2 triUV = -(uv - float2(size.x / 2, size.y / 2));
+
+    float halfWidth = 0.45 * size.x;
+    float halfHeight = 0.37 * size.y;
+    float fullWidth = halfWidth * 2;
+    float fullHeight = halfHeight * 2;
+    float bgTriangleDist = inflate(sdTriangleRight(triUV, halfWidth, halfHeight), 0.002);
+    ADD_ELEMENT(color, INACTIVE_COLOR, bgTriangleDist);
+
+    // Current active area
+    float remainingWidth = size.x - fullWidth;
+    float remainingHeight = size.y - fullHeight;
+    float marginX = remainingWidth / 2;
+    float marginY = remainingHeight / 2;
+
+    float invHitFade = 1 - _HitFade;
+    triUV.x += halfWidth * invHitFade;
+    float fgTriangleDist = inflate(sdTriangleRight(triUV, halfWidth * _HitFade, halfHeight), 0.002);
+    ADD_ELEMENT(color, ACTIVE_COLOR, fgTriangleDist);
+
+    // Slider handle
+    float handleDist = sdSphere(
+        translate(uv, float2(invHitFade * fullWidth + marginX, size.y * 0.5)),
+        HANDLE_RADIUS
+    );
+    ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
+
+    // Slider vertical grip
+    float gripDist = abs(uv.x - invHitFade * halfWidth * 2 - marginX) - OUTLINE_WIDTH;
+    ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
+
+    return color;
+}
+
+float3 drawExpFalloffArea(float2 uv, float2 size)
+{
+    float3 color = FOREGROUND_COLOR;
+
+    // Background fill
+    float2 triUV = -(uv - float2(size.x / 2, size.y / 2));
+
+    float halfWidth = 0.45 * size.x;
+    float halfHeight = 0.37 * size.y;
+    float fullWidth = halfWidth * 2;
+    float fullHeight = halfHeight * 2;
+    float bgTriangleDist = inflate(sdTriangleRight(triUV, halfWidth, halfHeight), 0.002);
+    ADD_ELEMENT(color, INACTIVE_COLOR, bgTriangleDist);
+
+    // Current active area
+    float remainingWidth = size.x - fullWidth;
+    float remainingHeight = size.y - fullHeight;
+    float marginX = remainingWidth / 2;
+    float marginY = remainingHeight / 2;
+    float triUVx = remap(uv.x, marginX, size.x-marginX, 0, 1);
+    float triUVy = remap(uv.y, marginY, size.y-marginY, 0, 1);
+
+    float expFalloffY = (1.0 + (pow(triUVx, 4.0) * _ExpFalloff) - _ExpFalloff) * triUVx;
+    float fgDist = inflate((1.0 - triUVy) - expFalloffY, 0.02);
+    ADD_ELEMENT(color, ACTIVE_COLOR, max(bgTriangleDist, fgDist*0.1));
+
+    // Slider handle
+    float handleDist = sdSphere(
+        translate(uv, float2(_ExpFalloff * fullWidth + marginX, size.y * 0.5)),
+        HANDLE_RADIUS
+    );
+    ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
+
+    // Slider vertical grip
+    float gripDist = abs(uv.x - _ExpFalloff * halfWidth * 2 - marginX) - OUTLINE_WIDTH;
+    ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
+
+    return color;
+}
+
+float3 drawFourBandArea(float2 uv, float2 size)
+{
+    float3 color = FOREGROUND_COLOR;
+
+    float2 sliceSize = float2(size.x, size.y / 4.0);
+    float strength = getBandAmplitudeLerp((uv.y / size.y) * 4.0, uv.x / size.x * 64.0);
+    float3 sliceColor = getBandColorLerp(uv.y / sliceSize.y);
+    sliceColor = saturate(lerp(sliceColor, sliceColor * 15, strength));
+
+    return sliceColor;
+}
+
+float3 drawHueArea(float2 uv, float2 size)
+{
+    float hue = uv.x / size.x;
+    float3 color = AudioLinkHSVtoRGB(float3(hue, 1.0, 1.0));
+
+    float sliderOffset = size.x * _Hue;
+    float handleDist = sdSphere(
+        translate(uv, float2(sliderOffset, size.y * 0.5)),
+        HANDLE_RADIUS
+    );
+    ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
+
+    float gripDist = abs(uv.x - sliderOffset) - OUTLINE_WIDTH;
+    ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
+
+    return color;
+}
+
+float3 drawSaturationArea(float2 uv, float2 size)
+{
+    float saturation = 1.0 - uv.y / size.y;
+    float3 color = AudioLinkHSVtoRGB(float3(_Hue, saturation, _Value));
+
+    float sliderOffset = size.y * (1 - _Saturation);
+    float handleDist = sdSphere(
+        translate(uv, float2(size.x * 0.5, sliderOffset)),
+        HANDLE_RADIUS
+    );
+    ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
+
+    float gripDist = abs(uv.y - sliderOffset) - OUTLINE_WIDTH;
+    ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
+
+    return color;
+}
+
+float3 drawValueArea(float2 uv, float2 size)
+{
+    float value = 1.0 - uv.y / size.y;
+    float3 color = AudioLinkHSVtoRGB(float3(_Hue, _Saturation, value));
+
+    float sliderOffset = size.y * (1 - _Value);
+    float handleDist = sdSphere(
+        translate(uv, float2(size.x * 0.5, sliderOffset)),
+        HANDLE_RADIUS
+    );
+    ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
+
+    float gripDist = abs(uv.y - sliderOffset) - OUTLINE_WIDTH;
+    ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
+
+    return color;
+}
+
+float3 drawColorChordToggle(float2 uv, float2 size)
+{
+    float colorIndex = uv.x / size.x * 3.97;
+    float3 a = AudioLinkData(ALPASS_THEME_COLOR0 + uint2(0, 0));
+    float3 b = AudioLinkData(ALPASS_THEME_COLOR0 + uint2(1, 0));
+    float3 c = AudioLinkData(ALPASS_THEME_COLOR0 + uint2(2, 0));
+    float3 d = AudioLinkData(ALPASS_THEME_COLOR0 + uint2(3, 0));
+
+    // If no music is playing, let's just show theme colors so it isn't black
+    if (!any(a) && !any(b) && !any(c) && !any(d))
+    {
+        a = _CustomColor0;
+        b = _CustomColor1;
+        c = _CustomColor2;
+        d = _CustomColor3;
+    }
+
+    return selectColorLerp(colorIndex, a, b, c, d);
+}
+
+float3 drawAutoCorrelatorArea(float2 uv, float2 size)
+{
+    float3 color = FOREGROUND_COLOR;
+
+    float2 scaledUV = uv / size;
+
+    float2 mirroredUV = abs(2 * (scaledUV - 0.5));
+    float3 autoCorrelator = AudioLinkLerp(ALPASS_AUTOCORRELATOR + float2(mirroredUV.x * AUDIOLINK_WIDTH, 0));
+    float scaledAutoCorrelator = abs(autoCorrelator.r * 0.007);
+
+    float middle = size.y * 0.5;
+    float autoCorrelatorDist = smoothstep(0.005, 0.003, middle - uv.y);
+    float autoCorrelatorDistAbs = abs(smoothstep(0.005, 0.003, abs(middle - uv.y) - scaledAutoCorrelator));
+
+    float4 vu = saturate(AudioLinkData(ALPASS_FILTEREDVU_INTENSITY) * 2.5);
+    float autoCorrelatorColor = lerp(FOREGROUND_COLOR, ACTIVE_COLOR, vu);
+    autoCorrelatorColor = lerp(autoCorrelatorColor, FOREGROUND_COLOR, smoothstep(0, 1, mirroredUV.x));
+
+    return lerp(BACKGROUND_COLOR * 0.8, autoCorrelatorColor, autoCorrelatorDistAbs);
+}
+
+float3 drawUI(float2 uv)
+{
+    float3 color = BACKGROUND_COLOR;
+
+    const float margin = 0.03;
+    float currentY = 0;
+
+    // Top area
+    float2 topAreaOrigin = translate(uv, FRAME_MARGIN);
+    float2 topAreaSize = float2(1.0 - FRAME_MARGIN * 2, 0.35);
+    float topAreaDist = sdRoundedBoxTopLeft(topAreaOrigin, topAreaSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawTopArea(topAreaOrigin), topAreaDist);
+    currentY += topAreaSize.y + margin;
+
+    const float gainSliderHeight = 0.13;
+    const float gainSliderWidth = topAreaSize.x - gainSliderHeight - margin;
+    const float fadeSliderHeight = 0.19;
+
+    // Gain slider
+    float2 gainSliderOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
+    float2 gainSliderSize = float2(gainSliderWidth, gainSliderHeight);
+    float gainSliderDist = sdRoundedBoxTopLeft(gainSliderOrigin, gainSliderSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawGainArea(gainSliderOrigin, gainSliderSize), gainSliderDist);
+
+    // Autogain button
+    float2 autogainButtonOrigin = translate(uv, FRAME_MARGIN + float2(gainSliderWidth + margin, currentY));
+    float2 autogainButtonSize = float2(gainSliderHeight, gainSliderHeight);
+    float autogainButtonDist = sdRoundedBoxTopLeft(autogainButtonOrigin, autogainButtonSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawAutoGainButton(autogainButtonOrigin, autogainButtonSize), autogainButtonDist);
+    currentY += autogainButtonSize.y + margin;
+
+    // Hit fade
+    float2 hitFadeAreaOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
+    float2 hitFadeAreaSize = float2(topAreaSize.x * 0.5 - margin * 0.5, fadeSliderHeight);
+    float hitFadeAreaDist = sdRoundedBoxTopLeft(hitFadeAreaOrigin, hitFadeAreaSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawHitFadeArea(hitFadeAreaOrigin, hitFadeAreaSize), hitFadeAreaDist);
+
+    // Exp fallof
+    float2 expFalloffAreaOrigin = translate(uv, FRAME_MARGIN + float2(hitFadeAreaSize.x + margin, currentY));
+    float2 expFalloffAreaSize = float2(topAreaSize.x * 0.5 - margin * 0.5, fadeSliderHeight);
+    float expFalloffAreaDist = sdRoundedBoxTopLeft(expFalloffAreaOrigin, expFalloffAreaSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawExpFalloffArea(expFalloffAreaOrigin, expFalloffAreaSize), expFalloffAreaDist);
+    currentY += expFalloffAreaSize.y + margin;
+
+    // 4-band
+    float2 fourBandOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
+    float2 fourBandSize = float2(topAreaSize.x, fadeSliderHeight);
+    float fourBandDist = sdRoundedBoxTopLeft(fourBandOrigin, fourBandSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawFourBandArea(fourBandOrigin, fourBandSize), fourBandDist);
+    currentY += fourBandSize.y + margin;
+
+    // Gray out irrelevant controls
+    float themeColorMultiplier = lerp(0.2, 1.0, _ThemeColorMode);
+    float colorChordMultiplier = lerp(1.0, 0.2, _ThemeColorMode);
+
+    // Theme colors
+    float colorWidth = topAreaSize.x * 0.25 - margin * 0.75;
+    float2 colorSize = float2(colorWidth, gainSliderHeight);
+    uint colorIndex = min(remap(uv.x, margin, 1-margin, 0, 4), 3);
+    float2 colorOrigin = translate(
+        uv, FRAME_MARGIN + float2(0, currentY) + float2(colorIndex * (colorSize.x + margin), 0));
+    float colorDist = sdRoundedBoxTopLeft(colorOrigin, colorSize, CORNER_RADIUS);
+    float3 colors[4] = {_CustomColor0, _CustomColor1, _CustomColor2, _CustomColor3};
+    if (fwidth(colorIndex) == 0)
+    {
+        ADD_ELEMENT(color, colors[colorIndex] * themeColorMultiplier, colorDist);
+
+        if (colorIndex == _SelectedColor % 4)
+        {
+            float shellDist = shell(colorDist, OUTLINE_WIDTH);
+            ADD_ELEMENT(color, ACTIVE_COLOR * themeColorMultiplier, shellDist);
+        }
+    }
+    currentY += colorSize.y + margin;
+
+    // Hue
+    float2 hueOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
+    float2 hueSize = float2(topAreaSize.x * 0.5 - margin * 0.5, 0.2);
+    float hueDist = sdRoundedBoxTopLeft(hueOrigin, hueSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawHueArea(hueOrigin, hueSize) * themeColorMultiplier, hueDist);
+
+    // Saturation / Value
+    float2 satOrigin = translate(uv, FRAME_MARGIN + float2(hueSize.x + margin, currentY));
+    float2 satSize = float2(colorSize.x / 2 - margin / 2, 0.2);
+    float satDist = sdRoundedBoxTopLeft(satOrigin, satSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawSaturationArea(satOrigin, satSize) * themeColorMultiplier, satDist);
+
+    float2 valOrigin = translate(uv, FRAME_MARGIN + float2(hueSize.x + satSize.x + margin * 2, currentY));
+    float2 valSize = satSize;
+    float valDist = sdRoundedBoxTopLeft(valOrigin, valSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawValueArea(valOrigin, valSize) * themeColorMultiplier, valDist);
+
+    // CC toggle
+    float2 ccToggleOrigin = translate(
+        uv, FRAME_MARGIN + float2(colorSize.x + margin, currentY) + float2(hueSize.x + margin, 0));
+    float2 ccToggleSize = float2(colorSize.x, 0.2);
+    float ccToggleDist = sdRoundedBoxTopLeft(ccToggleOrigin, ccToggleSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawColorChordToggle(ccToggleOrigin, ccToggleSize) * colorChordMultiplier, ccToggleDist);
+    if (_ThemeColorMode == 0)
+    {
+        float shellDist = shell(ccToggleDist, OUTLINE_WIDTH);
+        ADD_ELEMENT(color, ACTIVE_COLOR, shellDist);
+    }
+    currentY += hueSize.y + margin;
+
+    // Power button
+    float2 powerButtonOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
+    float2 powerButtonSize = float2(gainSliderHeight, gainSliderHeight);
+    float powerButtonDist = sdRoundedBoxTopLeft(powerButtonOrigin, powerButtonSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawPowerButton(powerButtonOrigin, powerButtonSize), powerButtonDist);
+
+    // Reset button
+    float2 resetButtonOrigin = translate(uv, FRAME_MARGIN + float2(gainSliderWidth + margin, currentY));
+    float2 resetButtonSize = float2(gainSliderHeight, gainSliderHeight);
+    float resetButtonDist = sdRoundedBoxTopLeft(resetButtonOrigin, resetButtonSize, CORNER_RADIUS);
+    ADD_ELEMENT(color, drawResetButton(resetButtonOrigin, resetButtonSize), resetButtonDist);
+
+    // Spectrogram area
+    float2 autoCorrelatorButtonOrigin = translate(uv, FRAME_MARGIN + float2(powerButtonSize.x + margin, currentY));
+    float2 autoCorrelatorButtonSize = float2(topAreaSize.x - powerButtonSize.x - resetButtonSize.x - margin * 2,
+                                             gainSliderHeight);
+    float autoCorrelatorButtonDist = sdRoundedBoxTopLeft(autoCorrelatorButtonOrigin, autoCorrelatorButtonSize,
+                                                         CORNER_RADIUS);
+    ADD_ELEMENT(color, drawAutoCorrelatorArea(autoCorrelatorButtonOrigin, autoCorrelatorButtonSize),
+                autoCorrelatorButtonDist);
+
+    return color;
+}
+
+#endif

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUI-Functions.cginc.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUI-Functions.cginc.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3f502152499b44d1b22f9f3bc08e42a3
+timeCreated: 1747535599

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUI.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUI.shader
@@ -44,7 +44,7 @@
             #pragma vertex vert
             #pragma fragment frag
             #include "UnityCG.cginc"
-            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            #include "AudioLinkUI-Functions.cginc"
 
             struct appdata
             {
@@ -58,7 +58,7 @@
                 float4 vertex : SV_POSITION;
             };
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
                 // Prevent z-fighting on mobile by moving the panel out a bit
@@ -70,702 +70,114 @@
                 return o;
             }
 
-            // Uniforms
-            float _Power;
-            float _Gain;
-            float _AutoGain;
-            float _Threshold0;
-            float _Threshold1;
-            float _Threshold2;
-            float _Threshold3;
-            float _X0;
-            float _X1;
-            float _X2;
-            float _X3;
-            float _HitFade;
-            float _ExpFalloff;
-            uint _ThemeColorMode;
-            uint _SelectedColor;
-            float _Hue;
-            float _Saturation;
-            float _Value;
-            float3 _CustomColor0;
-            float3 _CustomColor1;
-            float3 _CustomColor2;
-            float3 _CustomColor3;
-            sampler2D _GainTexture;
-            float4 _GainTexture_TexelSize;
-            sampler2D _AutoGainTexture;
-            float4 _AutoGainTexture_TexelSize;
-            sampler2D _PowerTexture;
-            float4 _PowerTexture_TexelSize;
-            sampler2D _ResetTexture;
-            float4 _ResetTexture_TexelSize;
-
-            // Colors
-            const static float3 BACKGROUND_COLOR = 0.033;
-            const static float3 FOREGROUND_COLOR = 0.075;
-            const static float3 INACTIVE_COLOR = 0.13;
-            const static float3 ACTIVE_COLOR = 0.8;
-            const static float3 BASS_COLOR_BG = pow(float3(44.0/255.0, 12.0/255.0, 43.0/255.0), 2.2);
-            const static float3 BASS_COLOR_MG = pow(float3(103.0/255.0, 27.0/255.0, 100.0/255.0), 2.2);
-            const static float3 BASS_COLOR_FG = pow(float3(147.0/255.0, 39.0/255.0, 143.0/255.0), 2.2);
-            const static float3 LOWMID_COLOR_BG = pow(float3(76.0/255.0, 53.0/255.0, 18.0/255.0), 2.2);
-            const static float3 HIGHMID_COLOR_BG = pow(float3(42.0/255.0, 60.0/255.0, 19.0/255.0), 2.2);
-            const static float3 HIGH_COLOR_BG = pow(float3(12.0/255.0, 52.0/255.0, 68.0/255.0), 2.2);
-            const static float3 HIGH_COLOR_FG = pow(float3(41.0/255.0, 171.0/255.0, 226.0/255.0), 2.2);
-
-            // Spacing
-            const static float CORNER_RADIUS = 0.025;
-            const static float FRAME_MARGIN = 0.03;
-            const static float HANDLE_RADIUS = 0.007;
-            const static float OUTLINE_WIDTH = 0.002;
-
-            #define remap(value, low1, high1, low2, high2) ((low2) + ((value) - (low1)) * ((high2) - (low2)) / ((high1) - (low1)))
-
-            #define COHERENT_CONDITION(condition) ((condition) || any(fwidth(condition)))
-            #define ADD_ELEMENT(existing, elementColor, elementDist) [branch] if (COHERENT_CONDITION(elementDist <= 0.01)) addElement(existing, elementColor, elementDist)
-
-            float3 selectColor(uint i, float3 a, float3 b, float3 c, float3 d)
-            {
-                return float4x4(
-                    float4(a, 0.0),
-                    float4(b, 0.0),
-                    float4(c, 0.0),
-                    float4(d, 0.0)
-                )[i % 4];
-            }
-
-            float3 selectColorLerp(float i, float3 a, float3 b, float3 c, float3 d)
-            {
-                int me = floor(i);
-                float3 meColor = selectColor(me, a, b, c, d);
-
-                // avoid singularity at 0.5
-                if (COHERENT_CONDITION(distance(frac(i), 0.5) < 0.1))
-                    return meColor;
-
-                int side = sign(frac(i) - 0.5);
-                int other = clamp(me + side, 0, 3);
-
-                float3 otherColor = selectColor(other, a, b, c, d);
-
-                float dist = round(i) - i;
-                const float pixelDiagonal = sqrt(2.0) / 2.0 * side;
-                float distDerivativeLength = sqrt(pow(ddx(dist), 2) + pow(ddy(dist), 2));
-
-                return lerp(otherColor, meColor, smoothstep(-pixelDiagonal, pixelDiagonal, dist/distDerivativeLength));
-            }
-
-            float3 getBandColor(uint i) { return selectColor(i, BASS_COLOR_BG, LOWMID_COLOR_BG, HIGHMID_COLOR_BG, HIGH_COLOR_BG); }
-            float3 getBandColorLerp(float i) { return selectColorLerp(i, BASS_COLOR_BG, LOWMID_COLOR_BG, HIGHMID_COLOR_BG, HIGH_COLOR_BG); }
-
-            // TODO: Deduplicate this
-            float3 getBandAmplitudeLerp(float i, float delay)
-            {
-                int me = floor(i);
-                float meStrength = AudioLinkLerp(float2(delay, me)).r;
-
-                // avoid singularity at 0.5
-                if (COHERENT_CONDITION(distance(frac(i), 0.5) < 0.1))
-                    return meStrength;
-
-                int side = sign(frac(i) - 0.5);
-                int other = clamp(me + side, 0, 3);
-
-                float otherStrength = AudioLinkLerp(float2(delay, other)).r;
-
-                float dist = round(i) - i;
-                const float pixelDiagonal = sqrt(2.0) / 2.0 * side;
-                float distDerivativeLength = sqrt(pow(ddx(dist), 2) + pow(ddy(dist), 2));
-
-                return lerp(otherStrength, meStrength, smoothstep(-pixelDiagonal, pixelDiagonal, dist/distDerivativeLength));
-            }
-
-            float2x2 rotationMatrix(float angle)
-            {
-                return float2x2(
-                    float2(cos(angle), -sin(angle)),
-                    float2(sin(angle), cos(angle))
-                );
-            }
-
-            float2 translate(float2 p, float2 offset)
-            {
-                return p - offset;
-            }
-
-            float2 rotate(float2 p, float angle)
-            {
-                return mul(rotationMatrix(angle), p);
-            }
-
-            float shell(float d, float thickness)
-            {
-                return abs(d) - thickness;
-            }
-
-            float inflate(float d, float thickness)
-            {
-                return d - thickness;
-            }
-
-            float lerpstep(float a, float b, float x)
-            {
-                return saturate((x - a)/(b - a));
-            }
-
-            void addElement(inout float3 existing, float3 elementColor, float elementDist)
-            {
-                const float pixelDiagonal = sqrt(2.0) / 2.0;
-                float distDerivativeLength = sqrt(pow(ddx(elementDist), 2) + pow(ddy(elementDist), 2));
-                existing = lerp(elementColor, existing, lerpstep(-pixelDiagonal, pixelDiagonal, elementDist/distDerivativeLength));
-            }
-
-            float sdRoundedBoxCentered(float2 p, float2 b, float4 r)
-            {
-                r.xy = (p.x>0.0)?r.xy : r.zw;
-                r.x  = (p.y>0.0)?r.x  : r.y;
-                float2 q = abs(p)-b*0.5+r.x;
-                return min(max(q.x,q.y),0.0) + length(max(q,0.0)) - r.x;
-            }
-
-            float sdRoundedBoxTopLeft(float2 p, float2 b, float4 r)
-            {
-                return sdRoundedBoxCentered(translate(p, b*0.5), b, r);
-            }
-
-            float sdRoundedBoxBottomRight(float2 p, float2 b, float4 r)
-            {
-                return sdRoundedBoxCentered(translate(p, float2(b.x,-b.y)*0.5), b, r);
-            }
-
-            float sdSphere(float2 p, float r)
-            {
-                return length(p) - r;
-            }
-
-            float sdTriangleIsosceles(float2 p, float2 q)
-            {
-                p.x = abs(p.x);
-                float2 a = p - q*clamp( dot(p,q)/dot(q,q), 0.0, 1.0 );
-                float2 b = p - q*float2( clamp( p.x/q.x, 0.0, 1.0 ), 1.0 );
-                float s = -sign( q.y );
-                float2 d = min( float2( dot(a,a), s*(p.x*q.y-p.y*q.x) ),
-                            float2( dot(b,b), s*(p.y-q.y)  ));
-                return -sqrt(d.x)*sign(d.y);
-            }
-
-            float sdTriangleRight(float2 p, float halfWidth, float halfHeight)
-            {
-                float2 end = float2(halfWidth, -halfHeight);
-                float2 d = p - end * clamp(dot(p, end) / dot(end, end), -1.0, 1.0);
-                if (max(d.x, d.y) > 0.0) {
-                return length(d);
-                }
-                p += float2(halfWidth, halfHeight);
-                if (max(p.x, p.y) > 0.0) {
-                    return -min(length(d), min(p.x, p.y));
-                }
-                return length(p);
-            }
-
-            float sdSegment(float2 p, float2 a, float2 b)
-            {
-                float2 pa = p-a, ba = b-a;
-                float h = clamp( dot(pa,ba)/dot(ba,ba), 0.0, 1.0 );
-                return length( pa - ba*h );
-            }
-
-            #define TEX2D_MSDF(tex, uv) tex2DMSDF(tex, tex##_TexelSize.xy * 4.0, uv)
-
-            float tex2DMSDF(sampler2D tex, float2 unit, float2 uv)
-            {
-                float3 c = tex2D(tex, uv).rgb;
-                return saturate(
-                    (max(min(c.r, c.g), min(max(c.r, c.g), c.b)) - 0.5) *
-                    max(dot(unit, 0.5 / fwidth(uv)), 1) + 0.5
-                );
-            }
-
-            float3 drawTopArea(float2 uv)
-            {
-                float3 color = FOREGROUND_COLOR;
-
-                float areaWidth = 1.0 - FRAME_MARGIN * 2;
-                float areaHeight = 0.35;
-                float handleWidth = 0.015 * areaWidth;
-
-                float threshold[4] = { _Threshold0, _Threshold1, _Threshold2, _Threshold3 };
-                float crossover[4] = { _X0 * areaWidth, _X1 * areaWidth, _X2 * areaWidth, _X3 * areaWidth };
-
-                // prefix sum to calculate offsets and sizes for boxes
-                uint start = 0;
-                uint stop = 4;
-                float currentBoxOffset = crossover[start];
-                float boxOffsets[4] = { 0, 0, 0, 0 };
-                float boxWidths[4] = { 0, 0, 0, 0 };
-                for (uint i = 0; i < 4; i++)
-                {
-                    float boxWidth = 0.0;
-                    if (i == 3) // The last box should just stretch to fill
-                        boxWidth = areaWidth - currentBoxOffset;
-                    else
-                        boxWidth = crossover[i + 1] - crossover[i];
-
-                    boxOffsets[i] = currentBoxOffset;
-                    boxWidths[i] = boxWidth;
-
-                    // Keep track of the range of boxes we need to draw
-                    if (COHERENT_CONDITION(uv.x > currentBoxOffset + OUTLINE_WIDTH))
-                        start = i;
-                    if (COHERENT_CONDITION(uv.x < currentBoxOffset + boxWidth - handleWidth))
-                        stop = min(stop, i + 1);
-
-                    currentBoxOffset += boxWidth;
-                }
-
-                // waveform calculation
-                uint totalBins = AUDIOLINK_EXPBINS * AUDIOLINK_EXPOCT;
-                uint noteno = AudioLinkRemap(uv.x, 0., 1., AUDIOLINK_4BAND_FREQFLOOR * totalBins, AUDIOLINK_4BAND_FREQCEILING * totalBins);
-                float notenof = AudioLinkRemap(uv.x, 0., 1., AUDIOLINK_4BAND_FREQFLOOR * totalBins, AUDIOLINK_4BAND_FREQCEILING * totalBins);
-                float4 specLow = AudioLinkData(float2(fmod(noteno, 128), (noteno/128)+4.0));
-                float4 specHigh = AudioLinkData(float2(fmod(noteno+1, 128), ((noteno+1)/128)+4.0));
-                float4 intensity = lerp(specLow, specHigh, frac(notenof)) * _Gain;
-                float bandIntensity = AudioLinkData(float2(0., start ^ 0)); // XOR with 0 to avoid FXC miscompilation
-                float funcY = areaHeight - (intensity.g * areaHeight);
-                float waveformDist = smoothstep(0.005, 0.003, funcY - uv.y);
-                float waveformDistAbs = abs(smoothstep(0.005, 0.003, abs(funcY - uv.y)));
-
-                // background waveform
-                color = lerp(color, color * 2, waveformDist);
-                color = lerp(color, color * 2, waveformDistAbs);
-
-                // This optimization increases performance, but introduces aliasing. The perf difference is only really noticeable on Quest.
-                #if defined(UNITY_PBS_USE_BRDF2) || defined(SHADER_API_MOBILE)
-                [loop] for (uint i = start; i < min(stop, 4); i++)
-                #else
-                for (uint i = 0; i < 4; i++)
-                #endif
-                {
-                    float boxHeight = threshold[i] * areaHeight;
-                    float boxWidth = boxWidths[i];
-                    float boxOffset = boxOffsets[i];
-
-                    float leftCornerRadius = i == 0 ? CORNER_RADIUS : 0.0;
-                    float rightCornerRadius = i == 3 ? CORNER_RADIUS : 0.0;
-                    float boxDist = sdRoundedBoxBottomRight(
-                        translate(uv, float2(boxOffset, areaHeight)),
-                        float2(boxWidth, boxHeight),
-                        float4(rightCornerRadius, CORNER_RADIUS, leftCornerRadius, CORNER_RADIUS)
-                    );
-
-                    // colored inner portion
-                    float3 innerColor = getBandColor(i);
-                    innerColor = lerp(innerColor, innerColor * 3, waveformDist);
-                    innerColor = lerp(innerColor, lerp(innerColor * 3, 1.0, bandIntensity > threshold[i]), waveformDistAbs);
-                    ADD_ELEMENT(color, innerColor, boxDist+OUTLINE_WIDTH);
-
-                    // outer shell
-                    float shellDist = shell(boxDist, OUTLINE_WIDTH);
-                    ADD_ELEMENT(color, ACTIVE_COLOR, shellDist);
-
-                    // Top pivot
-                    float handleDist = sdSphere(
-                        translate(uv, float2(boxWidth * 0.5 + boxOffset, areaHeight-boxHeight)),
-                        HANDLE_RADIUS
-                    );
-                    ADD_ELEMENT(color, 1.0, handleDist);
-
-                    // Side pivot
-                    handleDist = sdRoundedBoxCentered(
-                        translate(uv, float2(boxOffset, areaHeight - boxHeight * 0.5)),
-                        float2(handleWidth, 0.35 * boxHeight),
-                        HANDLE_RADIUS
-                    );
-                    ADD_ELEMENT(color, 1.0, handleDist);
-                }
-
-                return color;
-            }
-
-            float3 drawGainArea(float2 uv, float2 size)
-            {
-                float3 inactiveColor = INACTIVE_COLOR;
-                float3 activeColor = ACTIVE_COLOR;
-                float3 t = _Gain / 2.0f;
-
-                float3 color = FOREGROUND_COLOR;
-
-                float gainIcon = TEX2D_MSDF(_GainTexture, saturate((uv - float2(0.01, 0.0)) / size.y));
-                color = lerp(color, ACTIVE_COLOR, gainIcon.r);
-
-                const float sliderOffsetLeft = 0.16;
-                const float sliderOffsetRight = 0.02;
-
-                // Background fill
-                float maxTriangleWidth = size.x - sliderOffsetLeft - sliderOffsetRight;
-                float bgTriangleDist = inflate(sdTriangleIsosceles(
-                    rotate(translate(uv, float2(sliderOffsetLeft, size.y * 0.5)), UNITY_PI*0.5),
-                    float2(size.y*0.3, maxTriangleWidth)
-                ), 0.002);
-                ADD_ELEMENT(color, inactiveColor, bgTriangleDist);
-
-                // Current active area
-                float currentTriangleWidth = maxTriangleWidth * t;
-                float currentTriangleDist = max(bgTriangleDist, uv.x - currentTriangleWidth - sliderOffsetLeft);
-                ADD_ELEMENT(color, activeColor, currentTriangleDist);
-
-                // Slider handle
-                float handleDist = sdSphere(
-                    translate(uv, float2(currentTriangleWidth + sliderOffsetLeft, size.y * 0.5)),
-                    HANDLE_RADIUS
-                );
-                ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
-
-                // Slider vertical grip
-                float gripDist = abs(uv.x - currentTriangleWidth - sliderOffsetLeft) - OUTLINE_WIDTH;
-                ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
-
-                return color;
-            }
-
-            float drawAutoGainButton(float2 uv, float2 size)
-            {
-                float2 scaledUV = uv / size;
-                float autoGainIcon = TEX2D_MSDF(_AutoGainTexture, float2(scaledUV.x, 1-scaledUV.y));
-                return lerp(FOREGROUND_COLOR, _AutoGain ? ACTIVE_COLOR : INACTIVE_COLOR, autoGainIcon);
-            }
-
-            float drawPowerButton(float2 uv, float2 size)
-            {
-                float2 scaledUV = uv / size;
-                float powerIcon = TEX2D_MSDF(_PowerTexture, float2(scaledUV.x, 1-scaledUV.y));
-                return lerp(FOREGROUND_COLOR, _Power ? ACTIVE_COLOR : INACTIVE_COLOR, powerIcon);
-            }
-
-            float drawResetButton(float2 uv, float2 size)
-            {
-                float2 scaledUV = uv / size;
-                float resetIcon = TEX2D_MSDF(_ResetTexture, float2(scaledUV.x, 1-scaledUV.y));
-                return lerp(FOREGROUND_COLOR, ACTIVE_COLOR, resetIcon);
-            }
-
-            float3 drawHitFadeArea(float2 uv, float2 size)
-            {
-                float3 color = FOREGROUND_COLOR;
-
-                // Background fill
-                float2 triUV = -(uv - float2(size.x / 2, size.y / 2));
-
-                float halfWidth = 0.45 * size.x;
-                float halfHeight = 0.37 * size.y;
-                float fullWidth = halfWidth * 2;
-                float fullHeight = halfHeight * 2;
-                float bgTriangleDist = inflate(sdTriangleRight(triUV, halfWidth, halfHeight), 0.002);
-                ADD_ELEMENT(color, INACTIVE_COLOR, bgTriangleDist);
-
-                // Current active area
-                float remainingWidth = size.x - fullWidth;
-                float remainingHeight = size.y - fullHeight;
-                float marginX = remainingWidth / 2;
-                float marginY = remainingHeight / 2;
-
-                float invHitFade = 1 - _HitFade;
-                triUV.x += halfWidth * invHitFade;
-                float fgTriangleDist = inflate(sdTriangleRight(triUV, halfWidth * _HitFade, halfHeight), 0.002);
-                ADD_ELEMENT(color, ACTIVE_COLOR, fgTriangleDist);
-
-                // Slider handle
-                float handleDist = sdSphere(
-                    translate(uv, float2(invHitFade * fullWidth + marginX, size.y * 0.5)),
-                    HANDLE_RADIUS
-                );
-                ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
-
-                // Slider vertical grip
-                float gripDist = abs(uv.x - invHitFade * halfWidth * 2 - marginX) - OUTLINE_WIDTH;
-                ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
-
-                return color;
-            }
-
-            float3 drawExpFalloffArea(float2 uv, float2 size)
-            {
-                float3 color = FOREGROUND_COLOR;
-
-                // Background fill
-                float2 triUV = -(uv - float2(size.x / 2, size.y / 2));
-
-                float halfWidth = 0.45 * size.x;
-                float halfHeight = 0.37 * size.y;
-                float fullWidth = halfWidth * 2;
-                float fullHeight = halfHeight * 2;
-                float bgTriangleDist = inflate(sdTriangleRight(triUV, halfWidth, halfHeight), 0.002);
-                ADD_ELEMENT(color, INACTIVE_COLOR, bgTriangleDist);
-
-                // Current active area
-                float remainingWidth = size.x - fullWidth;
-                float remainingHeight = size.y - fullHeight;
-                float marginX = remainingWidth / 2;
-                float marginY = remainingHeight / 2;
-                float triUVx = remap(uv.x, marginX, size.x-marginX, 0, 1);
-                float triUVy = remap(uv.y, marginY, size.y-marginY, 0, 1);
-
-                float expFalloffY = (1.0 + (pow(triUVx, 4.0) * _ExpFalloff) - _ExpFalloff) * triUVx;
-                float fgDist = inflate((1.0 - triUVy) - expFalloffY, 0.02);
-                ADD_ELEMENT(color, ACTIVE_COLOR, max(bgTriangleDist, fgDist*0.1));
-
-                // Slider handle
-                float handleDist = sdSphere(
-                    translate(uv, float2(_ExpFalloff * fullWidth + marginX, size.y * 0.5)),
-                    HANDLE_RADIUS
-                );
-                ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
-
-                // Slider vertical grip
-                float gripDist = abs(uv.x - _ExpFalloff * halfWidth * 2 - marginX) - OUTLINE_WIDTH;
-                ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
-
-                return color;
-            }
-
-            float3 drawFourBandArea(float2 uv, float2 size)
-            {
-                float3 color = FOREGROUND_COLOR;
-
-                float2 sliceSize = float2(size.x, size.y / 4.0);
-                float strength = getBandAmplitudeLerp((uv.y / size.y) * 4.0, uv.x / size.x * 64.0);
-                float3 sliceColor = getBandColorLerp(uv.y / sliceSize.y);
-                sliceColor = saturate(lerp(sliceColor, sliceColor * 15, strength));
-
-                return sliceColor;
-            }
-
-            float3 drawHueArea(float2 uv, float2 size)
-            {
-                float hue = uv.x / size.x;
-                float3 color = AudioLinkHSVtoRGB(float3(hue, 1.0, 1.0));
-
-                float sliderOffset = size.x * _Hue;
-                float handleDist = sdSphere(
-                    translate(uv, float2(sliderOffset, size.y * 0.5)),
-                    HANDLE_RADIUS
-                );
-                ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
-
-                float gripDist = abs(uv.x - sliderOffset) - OUTLINE_WIDTH;
-                ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
-
-                return color;
-            }
-
-            float3 drawSaturationArea(float2 uv, float2 size)
-            {
-                float saturation = 1.0 - uv.y / size.y;
-                float3 color = AudioLinkHSVtoRGB(float3(_Hue, saturation, _Value));
-
-                float sliderOffset = size.y * (1 - _Saturation);
-                float handleDist = sdSphere(
-                    translate(uv, float2(size.x * 0.5, sliderOffset)),
-                    HANDLE_RADIUS
-                );
-                ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
-
-                float gripDist = abs(uv.y - sliderOffset) - OUTLINE_WIDTH;
-                ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
-
-                return color;
-            }
-
-            float3 drawValueArea(float2 uv, float2 size)
-            {
-                float value = 1.0 - uv.y / size.y;
-                float3 color = AudioLinkHSVtoRGB(float3(_Hue, _Saturation, value));
-
-                float sliderOffset = size.y * (1 - _Value);
-                float handleDist = sdSphere(
-                    translate(uv, float2(size.x * 0.5, sliderOffset)),
-                    HANDLE_RADIUS
-                );
-                ADD_ELEMENT(color, ACTIVE_COLOR, handleDist);
-
-                float gripDist = abs(uv.y - sliderOffset) - OUTLINE_WIDTH;
-                ADD_ELEMENT(color, ACTIVE_COLOR, gripDist);
-
-                return color;
-            }
-
-            float3 drawColorChordToggle(float2 uv, float2 size)
-            {
-                float colorIndex = uv.x / size.x * 3.97;
-                float3 a = AudioLinkData(ALPASS_THEME_COLOR0 + uint2(0, 0));
-                float3 b = AudioLinkData(ALPASS_THEME_COLOR0 + uint2(1, 0));
-                float3 c = AudioLinkData(ALPASS_THEME_COLOR0 + uint2(2, 0));
-                float3 d = AudioLinkData(ALPASS_THEME_COLOR0 + uint2(3, 0));
-
-                // If no music is playing, let's just show theme colors so it isn't black
-                if (!any(a) && !any(b) && !any(c) && !any(d))
-                {
-                    a = _CustomColor0;
-                    b = _CustomColor1;
-                    c = _CustomColor2;
-                    d = _CustomColor3;
-                }
-
-                return selectColorLerp(colorIndex, a, b, c, d);
-            }
-
-            float3 drawAutoCorrelatorArea(float2 uv, float2 size)
-            {
-                float3 color = FOREGROUND_COLOR;
-
-                float2 scaledUV = uv / size;
-
-                float2 mirroredUV = abs(2*(scaledUV - 0.5));
-                float3 autoCorrelator = AudioLinkLerp(ALPASS_AUTOCORRELATOR + float2(mirroredUV.x * AUDIOLINK_WIDTH, 0));
-                float scaledAutoCorrelator = abs(autoCorrelator.r*0.007);
-
-                float middle = size.y * 0.5;
-                float autoCorrelatorDist = smoothstep(0.005, 0.003, middle - uv.y);
-                float autoCorrelatorDistAbs = abs(smoothstep(0.005, 0.003, abs(middle - uv.y) - scaledAutoCorrelator));
-
-                float4 vu = saturate(AudioLinkData(ALPASS_FILTEREDVU_INTENSITY) * 2.5);
-                float autoCorrelatorColor = lerp(FOREGROUND_COLOR, ACTIVE_COLOR, vu);
-                autoCorrelatorColor = lerp(autoCorrelatorColor, FOREGROUND_COLOR, smoothstep(0, 1, mirroredUV.x));
-
-                return lerp(BACKGROUND_COLOR * 0.8, autoCorrelatorColor, autoCorrelatorDistAbs);
-            }
-
-            float3 drawUI(float2 uv)
-            {
-                float3 color = BACKGROUND_COLOR;
-
-                const float margin = 0.03;
-                float currentY = 0;
-
-                // Top area
-                float2 topAreaOrigin = translate(uv, FRAME_MARGIN);
-                float2 topAreaSize = float2(1.0 - FRAME_MARGIN * 2, 0.35);
-                float topAreaDist = sdRoundedBoxTopLeft(topAreaOrigin, topAreaSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawTopArea(topAreaOrigin), topAreaDist);
-                currentY += topAreaSize.y + margin;
-
-                const float gainSliderHeight = 0.13;
-                const float gainSliderWidth = topAreaSize.x - gainSliderHeight - margin;
-                const float fadeSliderHeight = 0.19;
-
-                // Gain slider
-                float2 gainSliderOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
-                float2 gainSliderSize = float2(gainSliderWidth, gainSliderHeight);
-                float gainSliderDist = sdRoundedBoxTopLeft(gainSliderOrigin, gainSliderSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawGainArea(gainSliderOrigin, gainSliderSize), gainSliderDist);
-
-                // Autogain button
-                float2 autogainButtonOrigin = translate(uv, FRAME_MARGIN + float2(gainSliderWidth + margin, currentY));
-                float2 autogainButtonSize = float2(gainSliderHeight, gainSliderHeight);
-                float autogainButtonDist = sdRoundedBoxTopLeft(autogainButtonOrigin, autogainButtonSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawAutoGainButton(autogainButtonOrigin, autogainButtonSize), autogainButtonDist);
-                currentY += autogainButtonSize.y + margin;
-
-                // Hit fade
-                float2 hitFadeAreaOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
-                float2 hitFadeAreaSize = float2(topAreaSize.x * 0.5 - margin * 0.5, fadeSliderHeight);
-                float hitFadeAreaDist = sdRoundedBoxTopLeft(hitFadeAreaOrigin, hitFadeAreaSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawHitFadeArea(hitFadeAreaOrigin, hitFadeAreaSize), hitFadeAreaDist);
-
-                // Exp fallof
-                float2 expFalloffAreaOrigin = translate(uv, FRAME_MARGIN + float2(hitFadeAreaSize.x + margin, currentY));
-                float2 expFalloffAreaSize = float2(topAreaSize.x * 0.5 - margin * 0.5, fadeSliderHeight);
-                float expFalloffAreaDist = sdRoundedBoxTopLeft(expFalloffAreaOrigin, expFalloffAreaSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawExpFalloffArea(expFalloffAreaOrigin, expFalloffAreaSize), expFalloffAreaDist);
-                currentY += expFalloffAreaSize.y + margin;
-
-                // 4-band
-                float2 fourBandOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
-                float2 fourBandSize = float2(topAreaSize.x, fadeSliderHeight);
-                float fourBandDist = sdRoundedBoxTopLeft(fourBandOrigin, fourBandSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawFourBandArea(fourBandOrigin, fourBandSize), fourBandDist);
-                currentY += fourBandSize.y + margin;
-
-                // Gray out irrelevant controls
-                float themeColorMultiplier = lerp(0.2, 1.0, _ThemeColorMode);
-                float colorChordMultiplier = lerp(1.0, 0.2, _ThemeColorMode);
-
-                // Theme colors
-                float colorWidth = topAreaSize.x * 0.25 - margin * 0.75;
-                float2 colorSize = float2(colorWidth, gainSliderHeight);
-                uint colorIndex = min(remap(uv.x, margin, 1-margin, 0, 4), 3);
-                float2 colorOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY) + float2(colorIndex * (colorSize.x + margin), 0));
-                float colorDist = sdRoundedBoxTopLeft(colorOrigin, colorSize, CORNER_RADIUS);
-                float3 colors[4] = { _CustomColor0, _CustomColor1, _CustomColor2, _CustomColor3 };
-                if (fwidth(colorIndex) == 0)
-                {
-                    ADD_ELEMENT(color, colors[colorIndex] * themeColorMultiplier, colorDist);
-
-                    if (colorIndex == _SelectedColor % 4)
-                    {
-                        float shellDist = shell(colorDist, OUTLINE_WIDTH);
-                        ADD_ELEMENT(color, ACTIVE_COLOR * themeColorMultiplier, shellDist);
-                    }
-                }
-                currentY += colorSize.y + margin;
-
-                // Hue
-                float2 hueOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
-                float2 hueSize = float2(topAreaSize.x * 0.5 - margin * 0.5, 0.2);
-                float hueDist = sdRoundedBoxTopLeft(hueOrigin, hueSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawHueArea(hueOrigin, hueSize) * themeColorMultiplier, hueDist);
-
-                // Saturation / Value
-                float2 satOrigin = translate(uv, FRAME_MARGIN + float2(hueSize.x + margin, currentY));
-                float2 satSize = float2(colorSize.x / 2 - margin / 2, 0.2);
-                float satDist = sdRoundedBoxTopLeft(satOrigin, satSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawSaturationArea(satOrigin, satSize) * themeColorMultiplier, satDist);
-
-                float2 valOrigin = translate(uv, FRAME_MARGIN + float2(hueSize.x + satSize.x + margin * 2, currentY));
-                float2 valSize = satSize;
-                float valDist = sdRoundedBoxTopLeft(valOrigin, valSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawValueArea(valOrigin, valSize) * themeColorMultiplier, valDist);
-
-                // CC toggle
-                float2 ccToggleOrigin = translate(uv, FRAME_MARGIN + float2(colorSize.x + margin, currentY) + float2(hueSize.x + margin, 0));
-                float2 ccToggleSize = float2(colorSize.x, 0.2);
-                float ccToggleDist = sdRoundedBoxTopLeft(ccToggleOrigin, ccToggleSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawColorChordToggle(ccToggleOrigin, ccToggleSize) * colorChordMultiplier, ccToggleDist);
-                if (_ThemeColorMode == 0)
-                {
-                    float shellDist = shell(ccToggleDist, OUTLINE_WIDTH);
-                    ADD_ELEMENT(color, ACTIVE_COLOR, shellDist);
-                }
-                currentY += hueSize.y + margin;
-
-                // Power button
-                float2 powerButtonOrigin = translate(uv, FRAME_MARGIN + float2(0, currentY));
-                float2 powerButtonSize = float2(gainSliderHeight, gainSliderHeight);
-                float powerButtonDist = sdRoundedBoxTopLeft(powerButtonOrigin, powerButtonSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawPowerButton(powerButtonOrigin, powerButtonSize), powerButtonDist);
-
-                // Reset button
-                float2 resetButtonOrigin = translate(uv, FRAME_MARGIN + float2(gainSliderWidth + margin, currentY));
-                float2 resetButtonSize = float2(gainSliderHeight, gainSliderHeight);
-                float resetButtonDist = sdRoundedBoxTopLeft(resetButtonOrigin, resetButtonSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawResetButton(resetButtonOrigin, resetButtonSize), resetButtonDist);
-
-                // Spectrogram area
-                float2 autoCorrelatorButtonOrigin = translate(uv, FRAME_MARGIN + float2(powerButtonSize.x + margin, currentY));
-                float2 autoCorrelatorButtonSize = float2(topAreaSize.x - powerButtonSize.x - resetButtonSize.x - margin * 2, gainSliderHeight);
-                float autoCorrelatorButtonDist = sdRoundedBoxTopLeft(autoCorrelatorButtonOrigin, autoCorrelatorButtonSize, CORNER_RADIUS);
-                ADD_ELEMENT(color, drawAutoCorrelatorArea(autoCorrelatorButtonOrigin, autoCorrelatorButtonSize), autoCorrelatorButtonDist);
-
-                return color;
-            }
-
-            float4 frag (v2f i) : SV_Target
+            float4 frag(v2f i) : SV_Target
             {
                 float2 uv = float2(i.uv.x, 1.0 - i.uv.y);
                 uv.y *= 0.3398717 / 0.218; // aspect ratio
                 return float4(drawUI(uv), 1);
+            }
+            ENDCG
+        }
+
+        // DepthOnly pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                #ifdef SHADER_API_MOBILE
+                v.vertex.z -= 0.0012;
+                #endif
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                #ifdef SHADER_API_MOBILE
+                v.vertex.z -= 0.0012;
+                #endif
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                return float4(normalWS * 0.5 + 0.5, 1);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUnlit.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUnlit.shader
@@ -1,0 +1,126 @@
+Shader "AudioLink/Unlit"
+{
+    Properties
+    {
+        _MainTex ("Base (RGB)", 2D) = "white" {}
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType"="Opaque"
+            "RenderingPipeline"="UniversalPipeline"
+        }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            #pragma multi_compile_fog
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_FOG_COORDS(1)
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                UNITY_TRANSFER_FOG(o, o.vertex);
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                fixed4 col = tex2D(_MainTex, i.texcoord);
+                return col;
+            }
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType"="Opaque"
+        }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            #pragma multi_compile_fog
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_FOG_COORDS(1)
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                UNITY_TRANSFER_FOG(o, o.vertex);
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                fixed4 col = tex2D(_MainTex, i.texcoord);
+                UNITY_APPLY_FOG(i.fogCoord, col);
+                    UNITY_OPAQUE_ALPHA(col.a);
+                return col;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUnlit.shader.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLinkUnlit.shader.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c4a032c0df4a77b43ad773530621e492
+timeCreated: 1747456318

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink_4Band.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink_4Band.shader
@@ -1,0 +1,224 @@
+Shader "AudioLink/Internal/AudioLink_4Band"
+{
+    Properties
+    {
+        _Band0Color("Band 0 Color", Color) = (0,0,0,0)
+        _Band1Color("Band 1 Color", Color) = (0,0,0,0)
+        _Band2Color("Band 2 Color", Color) = (0,0,0,0)
+        _Band3Color("Band 3 Color", Color) = (0,0,0,0)
+        [ToggleUI]_SmoothHistory("Smooth History", Float) = 0
+        _History("History", Range(0, 128)) = 32
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType"="Opaque"
+        }
+        LOD 100
+
+        Blend Off
+        AlphaToMask Off
+        Cull Back
+        ColorMask RGBA
+        ZWrite On
+        ZTest LEqual
+        Offset 0, 0
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_instancing
+            #pragma target 3.0
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 color : COLOR;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            float _SmoothHistory;
+            float _History;
+            float4 _Band0Color;
+            float4 _Band1Color;
+            float4 _Band2Color;
+            float4 _Band3Color;
+
+            inline float AudioLinkLerp3(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+
+                o.uv = v.uv;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(i);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+
+                float2 texCoord = i.uv;
+                float bandValue = texCoord.y * 4.0;
+                int band = (int)bandValue;
+
+                float historyValue = _History * texCoord.x;
+                float delay = _SmoothHistory ? historyValue : floor(historyValue);
+
+                float audioValue = AudioLinkLerp3(band, delay);
+                float4 audioColor = float4(audioValue, audioValue, audioValue, 1);
+
+                float bandNumber = floor(bandValue);
+                float4 bandColor = float4(0, 0, 0, 0);
+
+                if (bandNumber == 0.0)
+                    bandColor = _Band0Color;
+                else if (bandNumber == 1.0)
+                    bandColor = _Band1Color;
+                else if (bandNumber == 2.0)
+                    bandColor = _Band2Color;
+                else if (bandNumber == 3.0)
+                    bandColor = _Band3Color;
+
+                // Color blend operation (overlay blend)
+                float luminance = audioValue; // Simplified since audioValue is already grayscale
+
+                float4 finalColor;
+                if (luminance < 0.5)
+                    finalColor = 2.0 * audioColor * bandColor;
+                else
+                    finalColor = 1.0 - (2.0 * (1.0 - audioColor) * (1.0 - bandColor));
+
+                return finalColor;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_instancing
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_TARGET
+            {
+                UNITY_SETUP_INSTANCE_ID(i);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_instancing
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_TARGET
+            {
+                UNITY_SETUP_INSTANCE_ID(i);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+                float3 normal = normalize(i.normal);
+                return float4(normal * 0.5 + 0.5, 1);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink_4Band.shader.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink_4Band.shader.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6246efc53e5b44618a6500e712f3f118
+timeCreated: 1747719234

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface.shader
@@ -1,394 +1,401 @@
 // Upgrade NOTE: upgraded instancing buffer 'AudioLinkSurfaceAudioReactiveSurface' to new syntax.
 
 // Made with Amplify Shader Editor
-// Available at the Unity Asset Store - http://u3d.as/y3X 
+// Available at the Unity Asset Store - http://u3d.as/y3X
 Shader "AudioLink/Surface/AudioReactiveSurface"
 {
-	Properties
-	{
-		_MainTex("Albedo", 2D) = "white" {}
-		_Color("Color", Color) = (0.4980392,0.4980392,0.4980392,1)
-		_Metallic("Metallic", Range( 0 , 1)) = 0
-		_Smoothness("Smoothness", Range( 0 , 1)) = 0.5
-		_BumpMap("Normal Map", 2D) = "bump" {}
-		_BumpScale("Normal Scale", Float) = 1
-		_EmissionMap("Emission Map", 2D) = "gray" {}
-		[HDR]_EmissionColor("Emission Color", Color) = (0,0,0,1)
-		_Emission("Emission Scale", Float) = 1
-		[Header(Audio Section)][IntRange]_Band("Band", Range( 0 , 3)) = 0
-		_Delay("Delay", Range( 0 , 1)) = 0
-		[Header(Pulse Across UVs)]_Pulse("Pulse", Range( 0 , 1)) = 0
-		_AudioHueShift("Audio Hue Shift", Float) = 0
-		_PulseRotation("Pulse Rotation", Range( 0 , 360)) = 0
-		[HideInInspector] _texcoord( "", 2D ) = "white" {}
+    Properties
+    {
+        _MainTex("Albedo", 2D) = "white" {}
+        _Color("Color", Color) = (0.4980392,0.4980392,0.4980392,1)
+        _Metallic("Metallic", Range( 0 , 1)) = 0
+        _Smoothness("Smoothness", Range( 0 , 1)) = 0.5
+        _BumpMap("Normal Map", 2D) = "bump" {}
+        _BumpScale("Normal Scale", Float) = 1
+        _EmissionMap("Emission Map", 2D) = "gray" {}
+        [HDR]_EmissionColor("Emission Color", Color) = (0,0,0,1)
+        _Emission("Emission Scale", Float) = 1
+        [Header(Audio Section)][IntRange]_Band("Band", Range( 0 , 3)) = 0
+        _Delay("Delay", Range( 0 , 1)) = 0
+        [Header(Pulse Across UVs)]_Pulse("Pulse", Range( 0 , 1)) = 0
+        _AudioHueShift("Audio Hue Shift", Float) = 0
+        _PulseRotation("Pulse Rotation", Range( 0 , 360)) = 0
+        [HideInInspector] _texcoord( "", 2D ) = "white" {}
 
-		//_TransmissionShadow( "Transmission Shadow", Range( 0, 1 ) ) = 0.5
-		//_TransStrength( "Trans Strength", Range( 0, 50 ) ) = 1
-		//_TransNormal( "Trans Normal Distortion", Range( 0, 1 ) ) = 0.5
-		//_TransScattering( "Trans Scattering", Range( 1, 50 ) ) = 2
-		//_TransDirect( "Trans Direct", Range( 0, 1 ) ) = 0.9
-		//_TransAmbient( "Trans Ambient", Range( 0, 1 ) ) = 0.1
-		//_TransShadow( "Trans Shadow", Range( 0, 1 ) ) = 0.5
-		//_TessPhongStrength( "Tess Phong Strength", Range( 0, 1 ) ) = 0.5
-		//_TessValue( "Tess Max Tessellation", Range( 1, 32 ) ) = 16
-		//_TessMin( "Tess Min Distance", Float ) = 10
-		//_TessMax( "Tess Max Distance", Float ) = 25
-		//_TessEdgeLength ( "Tess Edge length", Range( 2, 50 ) ) = 16
-		//_TessMaxDisp( "Tess Max Displacement", Float ) = 25
-		//[ToggleOff] _SpecularHighlights("Specular Highlights", Float) = 1.0
-		//[ToggleOff] _GlossyReflections("Reflections", Float) = 1.0
-	}
-	
-	SubShader
-	{
-		
-		Tags { "RenderType"="Opaque" "Queue"="Geometry" "DisableBatching"="False" }
-	LOD 0
+        //_TransmissionShadow( "Transmission Shadow", Range( 0, 1 ) ) = 0.5
+        //_TransStrength( "Trans Strength", Range( 0, 50 ) ) = 1
+        //_TransNormal( "Trans Normal Distortion", Range( 0, 1 ) ) = 0.5
+        //_TransScattering( "Trans Scattering", Range( 1, 50 ) ) = 2
+        //_TransDirect( "Trans Direct", Range( 0, 1 ) ) = 0.9
+        //_TransAmbient( "Trans Ambient", Range( 0, 1 ) ) = 0.1
+        //_TransShadow( "Trans Shadow", Range( 0, 1 ) ) = 0.5
+        //_TessPhongStrength( "Tess Phong Strength", Range( 0, 1 ) ) = 0.5
+        //_TessValue( "Tess Max Tessellation", Range( 1, 32 ) ) = 16
+        //_TessMin( "Tess Min Distance", Float ) = 10
+        //_TessMax( "Tess Max Distance", Float ) = 25
+        //_TessEdgeLength ( "Tess Edge length", Range( 2, 50 ) ) = 16
+        //_TessMaxDisp( "Tess Max Displacement", Float ) = 25
+        //[ToggleOff] _SpecularHighlights("Specular Highlights", Float) = 1.0
+        //[ToggleOff] _GlossyReflections("Reflections", Float) = 1.0
+    }
 
-		Cull Back
-		AlphaToMask Off
-		ZWrite On
-		ZTest LEqual
-		ColorMask RGBA
-		
-		Blend Off
-		
+    SubShader
+    {
 
-		CGINCLUDE
-		#pragma target 3.0
+        Tags
+        {
+            "RenderType"="Opaque" "Queue"="Geometry" "DisableBatching"="False"
+        }
+        LOD 0
 
-		float4 FixedTess( float tessValue )
-		{
-			return tessValue;
-		}
-		
-		float CalcDistanceTessFactor (float4 vertex, float minDist, float maxDist, float tess, float4x4 o2w, float3 cameraPos )
-		{
-			float3 wpos = mul(o2w,vertex).xyz;
-			float dist = distance (wpos, cameraPos);
-			float f = clamp(1.0 - (dist - minDist) / (maxDist - minDist), 0.01, 1.0) * tess;
-			return f;
-		}
+        Cull Back
+        AlphaToMask Off
+        ZWrite On
+        ZTest LEqual
+        ColorMask RGBA
 
-		float4 CalcTriEdgeTessFactors (float3 triVertexFactors)
-		{
-			float4 tess;
-			tess.x = 0.5 * (triVertexFactors.y + triVertexFactors.z);
-			tess.y = 0.5 * (triVertexFactors.x + triVertexFactors.z);
-			tess.z = 0.5 * (triVertexFactors.x + triVertexFactors.y);
-			tess.w = (triVertexFactors.x + triVertexFactors.y + triVertexFactors.z) / 3.0f;
-			return tess;
-		}
+        Blend Off
 
-		float CalcEdgeTessFactor (float3 wpos0, float3 wpos1, float edgeLen, float3 cameraPos, float4 scParams )
-		{
-			float dist = distance (0.5 * (wpos0+wpos1), cameraPos);
-			float len = distance(wpos0, wpos1);
-			float f = max(len * scParams.y / (edgeLen * dist), 1.0);
-			return f;
-		}
 
-		float DistanceFromPlane (float3 pos, float4 plane)
-		{
-			float d = dot (float4(pos,1.0f), plane);
-			return d;
-		}
+        CGINCLUDE
+        #pragma target 3.0
 
-		bool WorldViewFrustumCull (float3 wpos0, float3 wpos1, float3 wpos2, float cullEps, float4 planes[6] )
-		{
-			float4 planeTest;
-			planeTest.x = (( DistanceFromPlane(wpos0, planes[0]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos1, planes[0]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos2, planes[0]) > -cullEps) ? 1.0f : 0.0f );
-			planeTest.y = (( DistanceFromPlane(wpos0, planes[1]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos1, planes[1]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos2, planes[1]) > -cullEps) ? 1.0f : 0.0f );
-			planeTest.z = (( DistanceFromPlane(wpos0, planes[2]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos1, planes[2]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos2, planes[2]) > -cullEps) ? 1.0f : 0.0f );
-			planeTest.w = (( DistanceFromPlane(wpos0, planes[3]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos1, planes[3]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos2, planes[3]) > -cullEps) ? 1.0f : 0.0f );
-			return !all (planeTest);
-		}
+        float4 FixedTess(float tessValue)
+        {
+            return tessValue;
+        }
 
-		float4 DistanceBasedTess( float4 v0, float4 v1, float4 v2, float tess, float minDist, float maxDist, float4x4 o2w, float3 cameraPos )
-		{
-			float3 f;
-			f.x = CalcDistanceTessFactor (v0,minDist,maxDist,tess,o2w,cameraPos);
-			f.y = CalcDistanceTessFactor (v1,minDist,maxDist,tess,o2w,cameraPos);
-			f.z = CalcDistanceTessFactor (v2,minDist,maxDist,tess,o2w,cameraPos);
+        float CalcDistanceTessFactor(float4 vertex, float minDist, float maxDist, float tess, float4x4 o2w,
+                                                                          float3 cameraPos)
+        {
+            float3 wpos = mul(o2w, vertex).xyz;
+            float dist = distance(wpos, cameraPos);
+            float f = clamp(1.0 - (dist - minDist) / (maxDist - minDist), 0.01, 1.0) * tess;
+            return f;
+        }
 
-			return CalcTriEdgeTessFactors (f);
-		}
+        float4 CalcTriEdgeTessFactors(float3 triVertexFactors)
+        {
+            float4 tess;
+            tess.x = 0.5 * (triVertexFactors.y + triVertexFactors.z);
+            tess.y = 0.5 * (triVertexFactors.x + triVertexFactors.z);
+            tess.z = 0.5 * (triVertexFactors.x + triVertexFactors.y);
+            tess.w = (triVertexFactors.x + triVertexFactors.y + triVertexFactors.z) / 3.0f;
+            return tess;
+        }
 
-		float4 EdgeLengthBasedTess( float4 v0, float4 v1, float4 v2, float edgeLength, float4x4 o2w, float3 cameraPos, float4 scParams )
-		{
-			float3 pos0 = mul(o2w,v0).xyz;
-			float3 pos1 = mul(o2w,v1).xyz;
-			float3 pos2 = mul(o2w,v2).xyz;
-			float4 tess;
-			tess.x = CalcEdgeTessFactor (pos1, pos2, edgeLength, cameraPos, scParams);
-			tess.y = CalcEdgeTessFactor (pos2, pos0, edgeLength, cameraPos, scParams);
-			tess.z = CalcEdgeTessFactor (pos0, pos1, edgeLength, cameraPos, scParams);
-			tess.w = (tess.x + tess.y + tess.z) / 3.0f;
-			return tess;
-		}
+        float CalcEdgeTessFactor(float3 wpos0, float3 wpos1, float edgeLen, float3 cameraPos, float4 scParams)
+        {
+            float dist = distance(0.5 * (wpos0 + wpos1), cameraPos);
+            float len = distance(wpos0, wpos1);
+            float f = max(len * scParams.y / (edgeLen * dist), 1.0);
+            return f;
+        }
 
-		float4 EdgeLengthBasedTessCull( float4 v0, float4 v1, float4 v2, float edgeLength, float maxDisplacement, float4x4 o2w, float3 cameraPos, float4 scParams, float4 planes[6] )
-		{
-			float3 pos0 = mul(o2w,v0).xyz;
-			float3 pos1 = mul(o2w,v1).xyz;
-			float3 pos2 = mul(o2w,v2).xyz;
-			float4 tess;
+        float DistanceFromPlane(float3 pos, float4 plane)
+        {
+            float d = dot(float4(pos, 1.0f), plane);
+            return d;
+        }
 
-			if (WorldViewFrustumCull(pos0, pos1, pos2, maxDisplacement, planes))
-			{
-				tess = 0.0f;
-			}
-			else
-			{
-				tess.x = CalcEdgeTessFactor (pos1, pos2, edgeLength, cameraPos, scParams);
-				tess.y = CalcEdgeTessFactor (pos2, pos0, edgeLength, cameraPos, scParams);
-				tess.z = CalcEdgeTessFactor (pos0, pos1, edgeLength, cameraPos, scParams);
-				tess.w = (tess.x + tess.y + tess.z) / 3.0f;
-			}
-			return tess;
-		}
-		ENDCG
+        bool WorldViewFrustumCull(float3 wpos0, float3 wpos1, float3 wpos2, float cullEps, float4 planes[6])
+        {
+            float4 planeTest;
+            planeTest.x = ((DistanceFromPlane(wpos0, planes[0]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos1, planes[0]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos2, planes[0]) > -cullEps) ? 1.0f : 0.0f);
+            planeTest.y = ((DistanceFromPlane(wpos0, planes[1]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos1, planes[1]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos2, planes[1]) > -cullEps) ? 1.0f : 0.0f);
+            planeTest.z = ((DistanceFromPlane(wpos0, planes[2]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos1, planes[2]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos2, planes[2]) > -cullEps) ? 1.0f : 0.0f);
+            planeTest.w = ((DistanceFromPlane(wpos0, planes[3]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos1, planes[3]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos2, planes[3]) > -cullEps) ? 1.0f : 0.0f);
+            return !all(planeTest);
+        }
 
-		
-		Pass
-		{
-			
-			Name "ForwardBase"
-			Tags { "LightMode"="ForwardBase" }
-			
-			Blend One Zero
+        float4 DistanceBasedTess(float4 v0, float4 v1, float4 v2, float tess, float minDist, float maxDist,
+                                                float4x4 o2w, float3 cameraPos)
+        {
+            float3 f;
+            f.x = CalcDistanceTessFactor(v0, minDist, maxDist, tess, o2w, cameraPos);
+            f.y = CalcDistanceTessFactor(v1, minDist, maxDist, tess, o2w, cameraPos);
+            f.z = CalcDistanceTessFactor(v2, minDist, maxDist, tess, o2w, cameraPos);
 
-			CGPROGRAM
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
+            return CalcTriEdgeTessFactors(f);
+        }
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma multi_compile_fwdbase
-			#ifndef UNITY_PASS_FORWARDBASE
-				#define UNITY_PASS_FORWARDBASE
-			#endif
-			#include "HLSLSupport.cginc"
-			#ifndef UNITY_INSTANCED_LOD_FADE
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#ifndef UNITY_INSTANCED_SH
-				#define UNITY_INSTANCED_SH
-			#endif
-			#ifndef UNITY_INSTANCED_LIGHTMAPSTS
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "AutoLight.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+        float4 EdgeLengthBasedTess(float4 v0, float4 v1, float4 v2, float edgeLength, float4x4 o2w, float3 cameraPos,
+                               float4 scParams)
+        {
+            float3 pos0 = mul(o2w, v0).xyz;
+            float3 pos1 = mul(o2w, v1).xyz;
+            float3 pos2 = mul(o2w, v2).xyz;
+            float4 tess;
+            tess.x = CalcEdgeTessFactor(pos1, pos2, edgeLength, cameraPos, scParams);
+            tess.y = CalcEdgeTessFactor(pos2, pos0, edgeLength, cameraPos, scParams);
+            tess.z = CalcEdgeTessFactor(pos0, pos1, edgeLength, cameraPos, scParams);
+            tess.w = (tess.x + tess.y + tess.z) / 3.0f;
+            return tess;
+        }
 
-			#pragma multi_compile_instancing
+        float4 EdgeLengthBasedTessCull(float4 v0, float4 v1, float4 v2, float edgeLength, float maxDisplacement,
+                    float4x4 o2w, float3 cameraPos, float4 scParams, float4 planes[6])
+        {
+            float3 pos0 = mul(o2w, v0).xyz;
+            float3 pos1 = mul(o2w, v1).xyz;
+            float3 pos2 = mul(o2w, v2).xyz;
+            float4 tess;
 
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
-			
-			struct v2f {
-				#if UNITY_VERSION >= 201810
+            if (WorldViewFrustumCull(pos0, pos1, pos2, maxDisplacement, planes))
+            {
+                tess = 0.0f;
+            }
+            else
+            {
+                tess.x = CalcEdgeTessFactor(pos1, pos2, edgeLength, cameraPos, scParams);
+                tess.y = CalcEdgeTessFactor(pos2, pos0, edgeLength, cameraPos, scParams);
+                tess.z = CalcEdgeTessFactor(pos0, pos1, edgeLength, cameraPos, scParams);
+                tess.w = (tess.x + tess.y + tess.z) / 3.0f;
+            }
+            return tess;
+        }
+        ENDCG
+
+
+        Pass
+        {
+            Blend One Zero
+
+            CGPROGRAM
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
+
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_fwdbase
+            #ifndef UNITY_PASS_FORWARDBASE
+            #define UNITY_PASS_FORWARDBASE
+            #endif
+            #include "HLSLSupport.cginc"
+            #ifndef UNITY_INSTANCED_LOD_FADE
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #ifndef UNITY_INSTANCED_SH
+            #define UNITY_INSTANCED_SH
+            #endif
+            #ifndef UNITY_INSTANCED_LIGHTMAPSTS
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "AutoLight.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            #pragma multi_compile_instancing
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+                float4 ase_texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                #if UNITY_VERSION >= 201810
 					UNITY_POSITION(pos);
-				#else
-					float4 pos : SV_POSITION;
-				#endif
-				#if defined(LIGHTMAP_ON) || (!defined(LIGHTMAP_ON) && SHADER_TARGET >= 30)
+                #else
+                float4 pos : SV_POSITION;
+                #endif
+                #if defined(LIGHTMAP_ON) || (!defined(LIGHTMAP_ON) && SHADER_TARGET >= 30)
 					float4 lmap : TEXCOORD0;
-				#endif
-				#if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH
+                #endif
+                #if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH
 					half3 sh : TEXCOORD1;
-				#endif
-				#if defined(UNITY_HALF_PRECISION_FRAGMENT_SHADER_REGISTERS) && UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #endif
+                #if defined(UNITY_HALF_PRECISION_FRAGMENT_SHADER_REGISTERS) && UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
 					UNITY_LIGHTING_COORDS(2,3)
-				#elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					#if UNITY_VERSION >= 201710
+                #elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201710
 						UNITY_SHADOW_COORDS(2)
-					#else
-						SHADOW_COORDS(2)
-					#endif
-				#endif
-				#ifdef ASE_FOG
-					UNITY_FOG_COORDS(4)
-				#endif
-				float4 tSpace0 : TEXCOORD5;
-				float4 tSpace1 : TEXCOORD6;
-				float4 tSpace2 : TEXCOORD7;
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #else
+                SHADOW_COORDS(2)
+                #endif
+                #endif
+                #ifdef ASE_FOG
+                UNITY_FOG_COORDS(4)
+                #endif
+                float4 tSpace0 : TEXCOORD5;
+                float4 tSpace1 : TEXCOORD6;
+                float4 tSpace2 : TEXCOORD7;
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 				float4 screenPos : TEXCOORD8;
-				#endif
-				float4 ase_texcoord9 : TEXCOORD9;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+                #endif
+                float4 ase_texcoord9 : TEXCOORD9;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
 
-			#ifdef _TRANSMISSION_ASE
+            #ifdef _TRANSMISSION_ASE
 				float _TransmissionShadow;
-			#endif
-			#ifdef _TRANSLUCENCY_ASE
+            #endif
+            #ifdef _TRANSLUCENCY_ASE
 				float _TransStrength;
 				float _TransNormal;
 				float _TransScattering;
 				float _TransDirect;
 				float _TransAmbient;
 				float _TransShadow;
-			#endif
-			#ifdef TESSELLATION_ON
+            #endif
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			uniform sampler2D _MainTex;
-			uniform float4 _Color;
-			uniform sampler2D _BumpMap;
-			uniform float _BumpScale;
-			uniform sampler2D _EmissionMap;
-			uniform float _Metallic;
-			uniform float _Smoothness;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
-				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
+            #endif
+            uniform sampler2D _MainTex;
+            uniform float4 _Color;
+            uniform sampler2D _BumpMap;
+            uniform float _BumpScale;
+            uniform sampler2D _EmissionMap;
+            uniform float _Metallic;
+            uniform float _Smoothness;
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
+                #define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
+                #define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
+                #define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
+                #define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Band)
+                #define _Band_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
+                #define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
+                #define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
+                #define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
+                #define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
-	
-			float3 HSVToRGB( float3 c )
-			{
-				float4 K = float4( 1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0 );
-				float3 p = abs( frac( c.xxx + K.xyz ) * 6.0 - K.www );
-				return c.z * lerp( K.xxx, saturate( p - K.xxx ), c.y );
-			}
-			
-			float3 RGBToHSV(float3 c)
-			{
-				float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-				float4 p = lerp( float4( c.bg, K.wz ), float4( c.gb, K.xy ), step( c.b, c.g ) );
-				float4 q = lerp( float4( p.xyw, c.r ), float4( c.r, p.yzx ), step( p.x, c.r ) );
-				float d = q.x - min( q.w, q.y );
-				float e = 1.0e-10;
-				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-			}
-			inline float AudioLinkLerp3_g6( int Band, float Delay )
-			{
-				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
-			}
-			
 
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+            float3 HSVToRGB(float3 c)
+            {
+                float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                float3 p = abs(frac(c.xxx + K.xyz) * 6.0 - K.www);
+                return c.z * lerp(K.xxx, saturate(p - K.xxx), c.y);
+            }
 
-				o.ase_texcoord9.xy = v.ase_texcoord.xy;
-				
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord9.zw = 0;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            float3 RGBToHSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            inline float AudioLinkLerp3_g6(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.ase_texcoord9.xy = v.ase_texcoord.xy;
+
+                //setting value to unused interpolator channels and avoid initialization warnings
+                o.ase_texcoord9.zw = 0;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				o.pos = UnityObjectToClipPos(v.vertex);
-				float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
-				fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
-				fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
-				fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
-				fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
-				o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
-				o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
-				o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
+                o.pos = UnityObjectToClipPos(v.vertex);
+                float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
+                fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
+                fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
+                fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
+                fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
+                o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
+                o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
+                o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
 
-				#ifdef DYNAMICLIGHTMAP_ON
+                #ifdef DYNAMICLIGHTMAP_ON
 				o.lmap.zw = v.texcoord2.xy * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
-				#endif
-				#ifdef LIGHTMAP_ON
+                #endif
+                #ifdef LIGHTMAP_ON
 				o.lmap.xy = v.texcoord1.xy * unity_LightmapST.xy + unity_LightmapST.zw;
-				#endif
+                #endif
 
-				#ifndef LIGHTMAP_ON
-					#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #ifndef LIGHTMAP_ON
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 						o.sh = 0;
-						#ifdef VERTEXLIGHT_ON
+                #ifdef VERTEXLIGHT_ON
 						o.sh += Shade4PointLights (
 							unity_4LightPosX0, unity_4LightPosY0, unity_4LightPosZ0,
 							unity_LightColor[0].rgb, unity_LightColor[1].rgb, unity_LightColor[2].rgb, unity_LightColor[3].rgb,
 							unity_4LightAtten0, worldPos, worldNormal);
-						#endif
+                #endif
 						o.sh = ShadeSHPerVertex (worldNormal, o.sh);
-					#endif
-				#endif
+                #endif
+                #endif
 
-				#if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
 					UNITY_TRANSFER_LIGHTING(o, v.texcoord1.xy);
-				#elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					#if UNITY_VERSION >= 201710
+                #elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201710
 						UNITY_TRANSFER_SHADOW(o, v.texcoord1.xy);
-					#else
-						TRANSFER_SHADOW(o);
-					#endif
-				#endif
+                #else
+                TRANSFER_SHADOW(o);
+                #endif
+                #endif
 
-				#ifdef ASE_FOG
-					UNITY_TRANSFER_FOG(o,o.pos);
-				#endif
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #ifdef ASE_FOG
+                UNITY_TRANSFER_FOG(o, o.pos);
+                #endif
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 					o.screenPos = ComputeScreenPos(o.pos);
-				#endif
-				return o;
-			}
+                #endif
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -427,15 +434,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -460,199 +467,207 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
 				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
-				#if defined(ASE_PHONG_TESSELLATION)
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
-			
-			fixed4 frag (v2f IN 
-				#ifdef _DEPTHOFFSET_ON
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
+
+            fixed4 frag(v2f IN
+                #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-				) : SV_Target 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
+                #endif
+            ) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
 
-				#ifdef LOD_FADE_CROSSFADE
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
-				float3 WorldTangent = float3(IN.tSpace0.x,IN.tSpace1.x,IN.tSpace2.x);
-				float3 WorldBiTangent = float3(IN.tSpace0.y,IN.tSpace1.y,IN.tSpace2.y);
-				float3 WorldNormal = float3(IN.tSpace0.z,IN.tSpace1.z,IN.tSpace2.z);
-				float3 worldPos = float3(IN.tSpace0.w,IN.tSpace1.w,IN.tSpace2.w);
-				float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
-				#if defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					UNITY_LIGHT_ATTENUATION(atten, IN, worldPos)
-				#else
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
+                float3 WorldTangent = float3(IN.tSpace0.x, IN.tSpace1.x, IN.tSpace2.x);
+                float3 WorldBiTangent = float3(IN.tSpace0.y, IN.tSpace1.y, IN.tSpace2.y);
+                float3 WorldNormal = float3(IN.tSpace0.z, IN.tSpace1.z, IN.tSpace2.z);
+                float3 worldPos = float3(IN.tSpace0.w, IN.tSpace1.w, IN.tSpace2.w);
+                float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
+                #if defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                UNITY_LIGHT_ATTENUATION(atten, IN, worldPos)
+                #else
 					half atten = 1;
-				#endif
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #endif
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 				float4 ScreenPos = IN.screenPos;
-				#endif
+                #endif
 
-				float2 texCoord6 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2D( _MainTex, texCoord6 ) * _Color ).rgb );
-				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
-				float hueShift33 = _AudioHueShift_Instance;
-				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g6 = (int)_Band_Instance;
-				float2 texCoord50 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g4 = texCoord50;
-				float temp_output_5_0_g4 = ( break6_g4.x - 0.5 );
-				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g4 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g4 = cos( temp_output_2_0_g4 );
-				float temp_output_8_0_g4 = sin( temp_output_2_0_g4 );
-				float temp_output_20_0_g4 = ( 1.0 / ( abs( temp_output_3_0_g4 ) + abs( temp_output_8_0_g4 ) ) );
-				float temp_output_7_0_g4 = ( break6_g4.y - 0.5 );
-				float2 appendResult16_g4 = (float2(( ( ( temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) + ( temp_output_7_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) - ( temp_output_5_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 )));
-				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
-				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g6 = ( ( (_Delay_Instance + (( appendResult16_g4.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6( Band3_g6 , Delay3_g6 );
-				float temp_output_96_0 = localAudioLinkLerp3_g6;
-				float amplitude36 = temp_output_96_0;
-				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
-				
-				float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
-				float2 uv_BumpMap = IN.ase_texcoord9.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
-				
-				float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
-				float2 uv_EmissionMap = IN.ase_texcoord9.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
-				float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
-				float3 hsvTorgb40 = RGBToHSV( ( tex2D( _EmissionMap, uv_EmissionMap ) * _EmissionColor_Instance * temp_output_96_0 ).rgb );
-				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
-				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
-				
-				o.Albedo = hsvTorgb39;
-				o.Normal = ( UnpackNormal( tex2D( _BumpMap, uv_BumpMap ) ) * _BumpScale );
-				o.Emission = ( hsvTorgb45 * _Emission_Instance );
-				#if defined(_SPECULAR_SETUP)
+                float2 texCoord6 = IN.ase_texcoord9.xy * float2(1, 1) + float2(0, 0);
+                float3 hsvTorgb32 = RGBToHSV((tex2D(_MainTex, texCoord6) * _Color).rgb);
+                float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
+                float hueShift33 = _AudioHueShift_Instance;
+                float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
+                int Band3_g6 = (int)_Band_Instance;
+                float2 texCoord50 = IN.ase_texcoord9.xy * float2(1, 1) + float2(0, 0);
+                float2 break6_g4 = texCoord50;
+                float temp_output_5_0_g4 = (break6_g4.x - 0.5);
+                float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
+                float temp_output_2_0_g4 = radians(_PulseRotation_Instance);
+                float temp_output_3_0_g4 = cos(temp_output_2_0_g4);
+                float temp_output_8_0_g4 = sin(temp_output_2_0_g4);
+                float temp_output_20_0_g4 = (1.0 / (abs(temp_output_3_0_g4) + abs(temp_output_8_0_g4)));
+                float temp_output_7_0_g4 = (break6_g4.y - 0.5);
+                float2 appendResult16_g4 = (float2(
+                    (((temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4) + (temp_output_7_0_g4 *
+                        temp_output_8_0_g4 * temp_output_20_0_g4)) + 0.5),
+                    (((temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4) - (temp_output_5_0_g4 *
+                        temp_output_8_0_g4 * temp_output_20_0_g4)) + 0.5)));
+                float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
+                float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
+                float Delay3_g6 = (((_Delay_Instance + ((appendResult16_g4.x * _Pulse_Instance) - 0.0) * (1.0 -
+                    _Delay_Instance) / (1.0 - 0.0)) % 1.0) * 128.0);
+                float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6(Band3_g6, Delay3_g6);
+                float temp_output_96_0 = localAudioLinkLerp3_g6;
+                float amplitude36 = temp_output_96_0;
+                float3 hsvTorgb39 = HSVToRGB(float3((hsvTorgb32.x + (hueShift33 * amplitude36)), hsvTorgb32.y,
+                            hsvTorgb32.z));
+
+                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
+                float2 uv_BumpMap = IN.ase_texcoord9.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
+
+                float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
+                float2 uv_EmissionMap = IN.ase_texcoord9.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
+                float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
+                float3 hsvTorgb40 = RGBToHSV(
+                    (tex2D(_EmissionMap, uv_EmissionMap) * _EmissionColor_Instance * temp_output_96_0).rgb);
+                float3 hsvTorgb45 = HSVToRGB(float3((hsvTorgb40.x + (hueShift33 * amplitude36)), hsvTorgb40.y,
+                         hsvTorgb40.z));
+                float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
+
+                o.Albedo = hsvTorgb39;
+                o.Normal = (UnpackNormal(tex2D(_BumpMap, uv_BumpMap)) * _BumpScale);
+                o.Emission = (hsvTorgb45 * _Emission_Instance);
+                #if defined(_SPECULAR_SETUP)
 					o.Specular = fixed3( 0, 0, 0 );
-				#else
-					o.Metallic = _Metallic;
-				#endif
-				o.Smoothness = _Smoothness;
-				o.Occlusion = 1;
-				o.Alpha = 1;
-				float AlphaClipThreshold = 0.5;
-				float AlphaClipThresholdShadow = 0.5;
-				float3 BakedGI = 0;
-				float3 RefractionColor = 1;
-				float RefractionIndex = 1;
-				float3 Transmission = 1;
-				float3 Translucency = 1;				
+                #else
+                o.Metallic = _Metallic;
+                #endif
+                o.Smoothness = _Smoothness;
+                o.Occlusion = 1;
+                o.Alpha = 1;
+                float AlphaClipThreshold = 0.5;
+                float AlphaClipThresholdShadow = 0.5;
+                float3 BakedGI = 0;
+                float3 RefractionColor = 1;
+                float RefractionIndex = 1;
+                float3 Transmission = 1;
+                float3 Translucency = 1;
 
-				#ifdef _ALPHATEST_ON
+                #ifdef _ALPHATEST_ON
 					clip( o.Alpha - AlphaClipThreshold );
-				#endif
+                #endif
 
-				#ifdef _DEPTHOFFSET_ON
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				#ifndef USING_DIRECTIONAL_LIGHT
-					fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
-				#else
+                #ifndef USING_DIRECTIONAL_LIGHT
+                fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
+                #else
 					fixed3 lightDir = _WorldSpaceLightPos0.xyz;
-				#endif
+                #endif
 
-				fixed4 c = 0;
-				float3 worldN;
-				worldN.x = dot(IN.tSpace0.xyz, o.Normal);
-				worldN.y = dot(IN.tSpace1.xyz, o.Normal);
-				worldN.z = dot(IN.tSpace2.xyz, o.Normal);
-				worldN = normalize(worldN);
-				o.Normal = worldN;
+                fixed4 c = 0;
+                float3 worldN;
+                worldN.x = dot(IN.tSpace0.xyz, o.Normal);
+                worldN.y = dot(IN.tSpace1.xyz, o.Normal);
+                worldN.z = dot(IN.tSpace2.xyz, o.Normal);
+                worldN = normalize(worldN);
+                o.Normal = worldN;
 
-				UnityGI gi;
-				UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
-				gi.indirect.diffuse = 0;
-				gi.indirect.specular = 0;
-				gi.light.color = _LightColor0.rgb;
-				gi.light.dir = lightDir;
+                UnityGI gi;
+                UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
+                gi.indirect.diffuse = 0;
+                gi.indirect.specular = 0;
+                gi.light.color = _LightColor0.rgb;
+                gi.light.dir = lightDir;
 
-				UnityGIInput giInput;
-				UNITY_INITIALIZE_OUTPUT(UnityGIInput, giInput);
-				giInput.light = gi.light;
-				giInput.worldPos = worldPos;
-				giInput.worldViewDir = worldViewDir;
-				giInput.atten = atten;
-				#if defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)
+                UnityGIInput giInput;
+                    UNITY_INITIALIZE_OUTPUT(UnityGIInput, giInput);
+                giInput.light = gi.light;
+                giInput.worldPos = worldPos;
+                giInput.worldViewDir = worldViewDir;
+                giInput.atten = atten;
+                #if defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)
 					giInput.lightmapUV = IN.lmap;
-				#else
-					giInput.lightmapUV = 0.0;
-				#endif
-				#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #else
+                giInput.lightmapUV = 0.0;
+                #endif
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 					giInput.ambient = IN.sh;
-				#else
-					giInput.ambient.rgb = 0.0;
-				#endif
-				giInput.probeHDR[0] = unity_SpecCube0_HDR;
-				giInput.probeHDR[1] = unity_SpecCube1_HDR;
-				#if defined(UNITY_SPECCUBE_BLENDING) || defined(UNITY_SPECCUBE_BOX_PROJECTION)
+                #else
+                giInput.ambient.rgb = 0.0;
+                #endif
+                giInput.probeHDR[0] = unity_SpecCube0_HDR;
+                giInput.probeHDR[1] = unity_SpecCube1_HDR;
+                #if defined(UNITY_SPECCUBE_BLENDING) || defined(UNITY_SPECCUBE_BOX_PROJECTION)
 					giInput.boxMin[0] = unity_SpecCube0_BoxMin;
-				#endif
-				#ifdef UNITY_SPECCUBE_BOX_PROJECTION
+                #endif
+                #ifdef UNITY_SPECCUBE_BOX_PROJECTION
 					giInput.boxMax[0] = unity_SpecCube0_BoxMax;
 					giInput.probePosition[0] = unity_SpecCube0_ProbePosition;
 					giInput.boxMax[1] = unity_SpecCube1_BoxMax;
 					giInput.boxMin[1] = unity_SpecCube1_BoxMin;
 					giInput.probePosition[1] = unity_SpecCube1_ProbePosition;
-				#endif
-				
-				#if defined(_SPECULAR_SETUP)
+                #endif
+
+                #if defined(_SPECULAR_SETUP)
 					LightingStandardSpecular_GI(o, giInput, gi);
-				#else
-					LightingStandard_GI( o, giInput, gi );
-				#endif
+                #else
+                LightingStandard_GI(o, giInput, gi);
+                #endif
 
-				#ifdef ASE_BAKEDGI
+                #ifdef ASE_BAKEDGI
 					gi.indirect.diffuse = BakedGI;
-				#endif
+                #endif
 
-				#if UNITY_SHOULD_SAMPLE_SH && !defined(LIGHTMAP_ON) && defined(ASE_NO_AMBIENT)
+                #if UNITY_SHOULD_SAMPLE_SH && !defined(LIGHTMAP_ON) && defined(ASE_NO_AMBIENT)
 					gi.indirect.diffuse = 0;
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					c += LightingStandardSpecular (o, worldViewDir, gi);
-				#else
-					c += LightingStandard( o, worldViewDir, gi );
-				#endif
-				
-				#ifdef _TRANSMISSION_ASE
+                #else
+                c += LightingStandard(o, worldViewDir, gi);
+                #endif
+
+                #ifdef _TRANSMISSION_ASE
 				{
 					float shadow = _TransmissionShadow;
-					#ifdef DIRECTIONAL
+                #ifdef DIRECTIONAL
 						float3 lightAtten = lerp( _LightColor0.rgb, gi.light.color, shadow );
-					#else
+                #else
 						float3 lightAtten = gi.light.color;
-					#endif
+                #endif
 					half3 transmission = max(0 , -dot(o.Normal, gi.light.dir)) * lightAtten * Transmission;
 					c.rgb += o.Albedo * transmission;
 				}
-				#endif
+                #endif
 
-				#ifdef _TRANSLUCENCY_ASE
+                #ifdef _TRANSLUCENCY_ASE
 				{
 					float shadow = _TransShadow;
 					float normal = _TransNormal;
@@ -661,243 +676,251 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 					float ambient = _TransAmbient;
 					float strength = _TransStrength;
 
-					#ifdef DIRECTIONAL
+                #ifdef DIRECTIONAL
 						float3 lightAtten = lerp( _LightColor0.rgb, gi.light.color, shadow );
-					#else
+                #else
 						float3 lightAtten = gi.light.color;
-					#endif
+                #endif
 					half3 lightDir = gi.light.dir + o.Normal * normal;
 					half transVdotL = pow( saturate( dot( worldViewDir, -lightDir ) ), scattering );
 					half3 translucency = lightAtten * (transVdotL * direct + gi.indirect.diffuse * ambient) * Translucency;
 					c.rgb += o.Albedo * translucency * strength;
 				}
-				#endif
+                #endif
 
-				//#ifdef _REFRACTION_ASE
-				//	float4 projScreenPos = ScreenPos / ScreenPos.w;
-				//	float3 refractionOffset = ( RefractionIndex - 1.0 ) * mul( UNITY_MATRIX_V, WorldNormal ).xyz * ( 1.0 - dot( WorldNormal, WorldViewDirection ) );
-				//	projScreenPos.xy += refractionOffset.xy;
-				//	float3 refraction = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _GrabTexture, projScreenPos ) * RefractionColor;
-				//	color.rgb = lerp( refraction, color.rgb, color.a );
-				//	color.a = 1;
-				//#endif
+                //#ifdef _REFRACTION_ASE
+                //	float4 projScreenPos = ScreenPos / ScreenPos.w;
+                //	float3 refractionOffset = ( RefractionIndex - 1.0 ) * mul( UNITY_MATRIX_V, WorldNormal ).xyz * ( 1.0 - dot( WorldNormal, WorldViewDirection ) );
+                //	projScreenPos.xy += refractionOffset.xy;
+                //	float3 refraction = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _GrabTexture, projScreenPos ) * RefractionColor;
+                //	color.rgb = lerp( refraction, color.rgb, color.a );
+                //	color.a = 1;
+                //#endif
 
-				c.rgb += o.Emission;
+                c.rgb += o.Emission;
 
-				#ifdef ASE_FOG
-					UNITY_APPLY_FOG(IN.fogCoord, c);
-				#endif
-				return c;
-			}
-			ENDCG
-		}
+                #ifdef ASE_FOG
+                UNITY_APPLY_FOG(IN.fogCoord, c);
+                #endif
+                return c;
+            }
+            ENDCG
+        }
 
-		
-		Pass
-		{
-			
-			Name "ForwardAdd"
-			Tags { "LightMode"="ForwardAdd" }
-			ZWrite Off
-			Blend One One
 
-			CGPROGRAM
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
+        Pass
+        {
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma skip_variants INSTANCING_ON
-			#pragma multi_compile_fwdadd_fullshadows
-			#ifndef UNITY_PASS_FORWARDADD
-				#define UNITY_PASS_FORWARDADD
-			#endif
-			#include "HLSLSupport.cginc"
-			#if !defined( UNITY_INSTANCED_LOD_FADE )
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#if !defined( UNITY_INSTANCED_SH )
-				#define UNITY_INSTANCED_SH
-			#endif
-			#if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "AutoLight.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            Name "ForwardAdd"
+            Tags
+            {
+                "LightMode"="ForwardAdd"
+            }
+            ZWrite Off
+            Blend One One
 
-			#pragma multi_compile_instancing
+            CGPROGRAM
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
 
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
-			struct v2f {
-				#if UNITY_VERSION >= 201810
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma skip_variants INSTANCING_ON
+            #pragma multi_compile_fwdadd_fullshadows
+            #ifndef UNITY_PASS_FORWARDADD
+            #define UNITY_PASS_FORWARDADD
+            #endif
+            #include "HLSLSupport.cginc"
+            #if !defined( UNITY_INSTANCED_LOD_FADE )
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #if !defined( UNITY_INSTANCED_SH )
+            #define UNITY_INSTANCED_SH
+            #endif
+            #if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "AutoLight.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            #pragma multi_compile_instancing
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+                float4 ase_texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                #if UNITY_VERSION >= 201810
 					UNITY_POSITION(pos);
-				#else
-					float4 pos : SV_POSITION;
-				#endif
-				#if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #else
+                float4 pos : SV_POSITION;
+                #endif
+                #if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
 					UNITY_LIGHTING_COORDS(1,2)
-				#elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					#if UNITY_VERSION >= 201710
+                #elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201710
 						UNITY_SHADOW_COORDS(1)
-					#else
-						SHADOW_COORDS(1)
-					#endif
-				#endif
-				#ifdef ASE_FOG
-					UNITY_FOG_COORDS(3)
-				#endif
-				float4 tSpace0 : TEXCOORD5;
-				float4 tSpace1 : TEXCOORD6;
-				float4 tSpace2 : TEXCOORD7;
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #else
+                SHADOW_COORDS(1)
+                #endif
+                #endif
+                #ifdef ASE_FOG
+                UNITY_FOG_COORDS(3)
+                #endif
+                float4 tSpace0 : TEXCOORD5;
+                float4 tSpace1 : TEXCOORD6;
+                float4 tSpace2 : TEXCOORD7;
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 				float4 screenPos : TEXCOORD8;
-				#endif
-				float4 ase_texcoord9 : TEXCOORD9;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+                #endif
+                float4 ase_texcoord9 : TEXCOORD9;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
 
-			#ifdef _TRANSMISSION_ASE
+            #ifdef _TRANSMISSION_ASE
 				float _TransmissionShadow;
-			#endif
-			#ifdef _TRANSLUCENCY_ASE
+            #endif
+            #ifdef _TRANSLUCENCY_ASE
 				float _TransStrength;
 				float _TransNormal;
 				float _TransScattering;
 				float _TransDirect;
 				float _TransAmbient;
 				float _TransShadow;
-			#endif
-			#ifdef TESSELLATION_ON
+            #endif
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			uniform sampler2D _MainTex;
-			uniform float4 _Color;
-			uniform sampler2D _BumpMap;
-			uniform float _BumpScale;
-			uniform sampler2D _EmissionMap;
-			uniform float _Metallic;
-			uniform float _Smoothness;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
-				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
+            #endif
+            uniform sampler2D _MainTex;
+            uniform float4 _Color;
+            uniform sampler2D _BumpMap;
+            uniform float _BumpScale;
+            uniform sampler2D _EmissionMap;
+            uniform float _Metallic;
+            uniform float _Smoothness;
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
+                #define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
+                #define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
+                #define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
+                #define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Band)
+                #define _Band_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
+                #define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
+                #define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
+                #define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
+                #define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
-	
-			float3 HSVToRGB( float3 c )
-			{
-				float4 K = float4( 1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0 );
-				float3 p = abs( frac( c.xxx + K.xyz ) * 6.0 - K.www );
-				return c.z * lerp( K.xxx, saturate( p - K.xxx ), c.y );
-			}
-			
-			float3 RGBToHSV(float3 c)
-			{
-				float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-				float4 p = lerp( float4( c.bg, K.wz ), float4( c.gb, K.xy ), step( c.b, c.g ) );
-				float4 q = lerp( float4( p.xyw, c.r ), float4( c.r, p.yzx ), step( p.x, c.r ) );
-				float d = q.x - min( q.w, q.y );
-				float e = 1.0e-10;
-				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-			}
-			inline float AudioLinkLerp3_g6( int Band, float Delay )
-			{
-				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
-			}
-			
 
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+            float3 HSVToRGB(float3 c)
+            {
+                float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                float3 p = abs(frac(c.xxx + K.xyz) * 6.0 - K.www);
+                return c.z * lerp(K.xxx, saturate(p - K.xxx), c.y);
+            }
 
-				o.ase_texcoord9.xy = v.ase_texcoord.xy;
-				
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord9.zw = 0;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            float3 RGBToHSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            inline float AudioLinkLerp3_g6(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                    UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.ase_texcoord9.xy = v.ase_texcoord.xy;
+
+                //setting value to unused interpolator channels and avoid initialization warnings
+                o.ase_texcoord9.zw = 0;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				o.pos = UnityObjectToClipPos(v.vertex);
-				float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
-				fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
-				fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
-				fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
-				fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
-				o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
-				o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
-				o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
+                o.pos = UnityObjectToClipPos(v.vertex);
+                float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
+                fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
+                fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
+                fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
+                fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
+                o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
+                o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
+                o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
 
-				#if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
 					UNITY_TRANSFER_LIGHTING(o, v.texcoord1.xy);
-				#elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					#if UNITY_VERSION >= 201710
+                #elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201710
 						UNITY_TRANSFER_SHADOW(o, v.texcoord1.xy);
-					#else
-						TRANSFER_SHADOW(o);
-					#endif
-				#endif
+                #else
+                TRANSFER_SHADOW(o);
+                #endif
+                #endif
 
-				#ifdef ASE_FOG
-					UNITY_TRANSFER_FOG(o,o.pos);
-				#endif
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #ifdef ASE_FOG
+                UNITY_TRANSFER_FOG(o, o.pos);
+                #endif
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 					o.screenPos = ComputeScreenPos(o.pos);
-				#endif
-				return o;
-			}
+                #endif
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -936,15 +959,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -969,154 +992,162 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
 				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
-				#if defined(ASE_PHONG_TESSELLATION)
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
 
-			fixed4 frag ( v2f IN 
-				#ifdef _DEPTHOFFSET_ON
+            fixed4 frag(v2f IN
+                #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-				) : SV_Target 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
+                #endif
+            ) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
 
-				#ifdef LOD_FADE_CROSSFADE
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
-				float3 WorldTangent = float3(IN.tSpace0.x,IN.tSpace1.x,IN.tSpace2.x);
-				float3 WorldBiTangent = float3(IN.tSpace0.y,IN.tSpace1.y,IN.tSpace2.y);
-				float3 WorldNormal = float3(IN.tSpace0.z,IN.tSpace1.z,IN.tSpace2.z);
-				float3 worldPos = float3(IN.tSpace0.w,IN.tSpace1.w,IN.tSpace2.w);
-				float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
-				#if defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					UNITY_LIGHT_ATTENUATION(atten, IN, worldPos)
-				#else
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
+                float3 WorldTangent = float3(IN.tSpace0.x, IN.tSpace1.x, IN.tSpace2.x);
+                float3 WorldBiTangent = float3(IN.tSpace0.y, IN.tSpace1.y, IN.tSpace2.y);
+                float3 WorldNormal = float3(IN.tSpace0.z, IN.tSpace1.z, IN.tSpace2.z);
+                float3 worldPos = float3(IN.tSpace0.w, IN.tSpace1.w, IN.tSpace2.w);
+                float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
+                #if defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                UNITY_LIGHT_ATTENUATION(atten, IN, worldPos)
+                #else
 					half atten = 1;
-				#endif
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #endif
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 				float4 ScreenPos = IN.screenPos;
-				#endif
+                #endif
 
 
-				float2 texCoord6 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2D( _MainTex, texCoord6 ) * _Color ).rgb );
-				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
-				float hueShift33 = _AudioHueShift_Instance;
-				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g6 = (int)_Band_Instance;
-				float2 texCoord50 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g4 = texCoord50;
-				float temp_output_5_0_g4 = ( break6_g4.x - 0.5 );
-				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g4 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g4 = cos( temp_output_2_0_g4 );
-				float temp_output_8_0_g4 = sin( temp_output_2_0_g4 );
-				float temp_output_20_0_g4 = ( 1.0 / ( abs( temp_output_3_0_g4 ) + abs( temp_output_8_0_g4 ) ) );
-				float temp_output_7_0_g4 = ( break6_g4.y - 0.5 );
-				float2 appendResult16_g4 = (float2(( ( ( temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) + ( temp_output_7_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) - ( temp_output_5_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 )));
-				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
-				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g6 = ( ( (_Delay_Instance + (( appendResult16_g4.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6( Band3_g6 , Delay3_g6 );
-				float temp_output_96_0 = localAudioLinkLerp3_g6;
-				float amplitude36 = temp_output_96_0;
-				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
-				
-				float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
-				float2 uv_BumpMap = IN.ase_texcoord9.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
-				
-				float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
-				float2 uv_EmissionMap = IN.ase_texcoord9.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
-				float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
-				float3 hsvTorgb40 = RGBToHSV( ( tex2D( _EmissionMap, uv_EmissionMap ) * _EmissionColor_Instance * temp_output_96_0 ).rgb );
-				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
-				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
-				
-				o.Albedo = hsvTorgb39;
-				o.Normal = ( UnpackNormal( tex2D( _BumpMap, uv_BumpMap ) ) * _BumpScale );
-				o.Emission = ( hsvTorgb45 * _Emission_Instance );
-				#if defined(_SPECULAR_SETUP)
+                float2 texCoord6 = IN.ase_texcoord9.xy * float2(1, 1) + float2(0, 0);
+                float3 hsvTorgb32 = RGBToHSV((tex2D(_MainTex, texCoord6) * _Color).rgb);
+                float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
+                float hueShift33 = _AudioHueShift_Instance;
+                float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
+                int Band3_g6 = (int)_Band_Instance;
+                float2 texCoord50 = IN.ase_texcoord9.xy * float2(1, 1) + float2(0, 0);
+                float2 break6_g4 = texCoord50;
+                float temp_output_5_0_g4 = (break6_g4.x - 0.5);
+                float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
+                float temp_output_2_0_g4 = radians(_PulseRotation_Instance);
+                float temp_output_3_0_g4 = cos(temp_output_2_0_g4);
+                float temp_output_8_0_g4 = sin(temp_output_2_0_g4);
+                float temp_output_20_0_g4 = (1.0 / (abs(temp_output_3_0_g4) + abs(temp_output_8_0_g4)));
+                float temp_output_7_0_g4 = (break6_g4.y - 0.5);
+                float2 appendResult16_g4 = (float2(
+                    (((temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4) + (temp_output_7_0_g4 *
+                        temp_output_8_0_g4 * temp_output_20_0_g4)) + 0.5),
+                    (((temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4) - (temp_output_5_0_g4 *
+                        temp_output_8_0_g4 * temp_output_20_0_g4)) + 0.5)));
+                float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
+                float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
+                float Delay3_g6 = (((_Delay_Instance + ((appendResult16_g4.x * _Pulse_Instance) - 0.0) * (1.0 -
+                    _Delay_Instance) / (1.0 - 0.0)) % 1.0) * 128.0);
+                float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6(Band3_g6, Delay3_g6);
+                float temp_output_96_0 = localAudioLinkLerp3_g6;
+                float amplitude36 = temp_output_96_0;
+                float3 hsvTorgb39 = HSVToRGB(float3((hsvTorgb32.x + (hueShift33 * amplitude36)), hsvTorgb32.y,
+                                                                            hsvTorgb32.z));
+
+                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
+                float2 uv_BumpMap = IN.ase_texcoord9.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
+
+                float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
+                float2 uv_EmissionMap = IN.ase_texcoord9.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
+                float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
+                float3 hsvTorgb40 = RGBToHSV(
+                    (tex2D(_EmissionMap, uv_EmissionMap) * _EmissionColor_Instance * temp_output_96_0).rgb);
+                float3 hsvTorgb45 = HSVToRGB(float3((hsvTorgb40.x + (hueShift33 * amplitude36)), hsvTorgb40.y,
+                                      hsvTorgb40.z));
+                float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
+
+                o.Albedo = hsvTorgb39;
+                o.Normal = (UnpackNormal(tex2D(_BumpMap, uv_BumpMap)) * _BumpScale);
+                o.Emission = (hsvTorgb45 * _Emission_Instance);
+                #if defined(_SPECULAR_SETUP)
 					o.Specular = fixed3( 0, 0, 0 );
-				#else
-					o.Metallic = _Metallic;
-				#endif
-				o.Smoothness = _Smoothness;
-				o.Occlusion = 1;
-				o.Alpha = 1;
-				float AlphaClipThreshold = 0.5;
-				float3 Transmission = 1;
-				float3 Translucency = 1;		
+                #else
+                o.Metallic = _Metallic;
+                #endif
+                o.Smoothness = _Smoothness;
+                o.Occlusion = 1;
+                o.Alpha = 1;
+                float AlphaClipThreshold = 0.5;
+                float3 Transmission = 1;
+                float3 Translucency = 1;
 
-				#ifdef _ALPHATEST_ON
+                #ifdef _ALPHATEST_ON
 					clip( o.Alpha - AlphaClipThreshold );
-				#endif
+                #endif
 
-				#ifdef _DEPTHOFFSET_ON
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				#ifndef USING_DIRECTIONAL_LIGHT
-					fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
-				#else
+                #ifndef USING_DIRECTIONAL_LIGHT
+                fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
+                #else
 					fixed3 lightDir = _WorldSpaceLightPos0.xyz;
-				#endif
+                #endif
 
-				fixed4 c = 0;
-				float3 worldN;
-				worldN.x = dot(IN.tSpace0.xyz, o.Normal);
-				worldN.y = dot(IN.tSpace1.xyz, o.Normal);
-				worldN.z = dot(IN.tSpace2.xyz, o.Normal);
-				worldN = normalize(worldN);
-				o.Normal = worldN;
+                fixed4 c = 0;
+                float3 worldN;
+                worldN.x = dot(IN.tSpace0.xyz, o.Normal);
+                worldN.y = dot(IN.tSpace1.xyz, o.Normal);
+                worldN.z = dot(IN.tSpace2.xyz, o.Normal);
+                worldN = normalize(worldN);
+                o.Normal = worldN;
 
-				UnityGI gi;
-				UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
-				gi.indirect.diffuse = 0;
-				gi.indirect.specular = 0;
-				gi.light.color = _LightColor0.rgb;
-				gi.light.dir = lightDir;
-				gi.light.color *= atten;
+                UnityGI gi;
+                UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
+                gi.indirect.diffuse = 0;
+                gi.indirect.specular = 0;
+                gi.light.color = _LightColor0.rgb;
+                gi.light.dir = lightDir;
+                gi.light.color *= atten;
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					c += LightingStandardSpecular( o, worldViewDir, gi );
-				#else
-					c += LightingStandard( o, worldViewDir, gi );
-				#endif
-				
-				#ifdef _TRANSMISSION_ASE
+                #else
+                c += LightingStandard(o, worldViewDir, gi);
+                #endif
+
+                #ifdef _TRANSMISSION_ASE
 				{
 					float shadow = _TransmissionShadow;
-					#ifdef DIRECTIONAL
+                #ifdef DIRECTIONAL
 						float3 lightAtten = lerp( _LightColor0.rgb, gi.light.color, shadow );
-					#else
+                #else
 						float3 lightAtten = gi.light.color;
-					#endif
+                #endif
 					half3 transmission = max(0 , -dot(o.Normal, gi.light.dir)) * lightAtten * Transmission;
 					c.rgb += o.Albedo * transmission;
 				}
-				#endif
+                #endif
 
-				#ifdef _TRANSLUCENCY_ASE
+                #ifdef _TRANSLUCENCY_ASE
 				{
 					float shadow = _TransShadow;
 					float normal = _TransNormal;
@@ -1125,233 +1156,240 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 					float ambient = _TransAmbient;
 					float strength = _TransStrength;
 
-					#ifdef DIRECTIONAL
+                #ifdef DIRECTIONAL
 						float3 lightAtten = lerp( _LightColor0.rgb, gi.light.color, shadow );
-					#else
+                #else
 						float3 lightAtten = gi.light.color;
-					#endif
+                #endif
 					half3 lightDir = gi.light.dir + o.Normal * normal;
 					half transVdotL = pow( saturate( dot( worldViewDir, -lightDir ) ), scattering );
 					half3 translucency = lightAtten * (transVdotL * direct + gi.indirect.diffuse * ambient) * Translucency;
 					c.rgb += o.Albedo * translucency * strength;
 				}
-				#endif
+                #endif
 
-				//#ifdef _REFRACTION_ASE
-				//	float4 projScreenPos = ScreenPos / ScreenPos.w;
-				//	float3 refractionOffset = ( RefractionIndex - 1.0 ) * mul( UNITY_MATRIX_V, WorldNormal ).xyz * ( 1.0 - dot( WorldNormal, WorldViewDirection ) );
-				//	projScreenPos.xy += refractionOffset.xy;
-				//	float3 refraction = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _GrabTexture, projScreenPos ) * RefractionColor;
-				//	color.rgb = lerp( refraction, color.rgb, color.a );
-				//	color.a = 1;
-				//#endif
+                //#ifdef _REFRACTION_ASE
+                //	float4 projScreenPos = ScreenPos / ScreenPos.w;
+                //	float3 refractionOffset = ( RefractionIndex - 1.0 ) * mul( UNITY_MATRIX_V, WorldNormal ).xyz * ( 1.0 - dot( WorldNormal, WorldViewDirection ) );
+                //	projScreenPos.xy += refractionOffset.xy;
+                //	float3 refraction = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _GrabTexture, projScreenPos ) * RefractionColor;
+                //	color.rgb = lerp( refraction, color.rgb, color.a );
+                //	color.a = 1;
+                //#endif
 
-				#ifdef ASE_FOG
-					UNITY_APPLY_FOG(IN.fogCoord, c);
-				#endif
-				return c;
-			}
-			ENDCG
-		}
+                #ifdef ASE_FOG
+                UNITY_APPLY_FOG(IN.fogCoord, c);
+                #endif
+                return c;
+            }
+            ENDCG
+        }
 
-		
-		Pass
-		{
-			
-			Name "Deferred"
-			Tags { "LightMode"="Deferred" }
 
-			AlphaToMask Off
+        Pass
+        {
 
-			CGPROGRAM
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
+            Name "Deferred"
+            Tags
+            {
+                "LightMode"="Deferred"
+            }
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma target 3.0
-			#pragma exclude_renderers nomrt
-			#pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
-			#pragma multi_compile_prepassfinal
-			#ifndef UNITY_PASS_DEFERRED
-				#define UNITY_PASS_DEFERRED
-			#endif
-			#include "HLSLSupport.cginc"
-			#if !defined( UNITY_INSTANCED_LOD_FADE )
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#if !defined( UNITY_INSTANCED_SH )
-				#define UNITY_INSTANCED_SH
-			#endif
-			#if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            AlphaToMask Off
 
-			#pragma multi_compile_instancing
+            CGPROGRAM
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
 
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 3.0
+            #pragma exclude_renderers nomrt
+            #pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
+            #pragma multi_compile_prepassfinal
+            #ifndef UNITY_PASS_DEFERRED
+            #define UNITY_PASS_DEFERRED
+            #endif
+            #include "HLSLSupport.cginc"
+            #if !defined( UNITY_INSTANCED_LOD_FADE )
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #if !defined( UNITY_INSTANCED_SH )
+            #define UNITY_INSTANCED_SH
+            #endif
+            #if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
 
-			struct v2f {
-				#if UNITY_VERSION >= 201810
+            #pragma multi_compile_instancing
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+                float4 ase_texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                #if UNITY_VERSION >= 201810
 					UNITY_POSITION(pos);
-				#else
-					float4 pos : SV_POSITION;
-				#endif
-				float4 lmap : TEXCOORD2;
-				#ifndef LIGHTMAP_ON
-					#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #else
+                float4 pos : SV_POSITION;
+                #endif
+                float4 lmap : TEXCOORD2;
+                #ifndef LIGHTMAP_ON
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 						half3 sh : TEXCOORD3;
-					#endif
-				#else
-					#ifdef DIRLIGHTMAP_OFF
+                #endif
+                #else
+                #ifdef DIRLIGHTMAP_OFF
 						float4 lmapFadePos : TEXCOORD4;
-					#endif
-				#endif
-				float4 tSpace0 : TEXCOORD5;
-				float4 tSpace1 : TEXCOORD6;
-				float4 tSpace2 : TEXCOORD7;
-				float4 ase_texcoord8 : TEXCOORD8;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+                #endif
+                #endif
+                float4 tSpace0 : TEXCOORD5;
+                float4 tSpace1 : TEXCOORD6;
+                float4 tSpace2 : TEXCOORD7;
+                float4 ase_texcoord8 : TEXCOORD8;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
 
-			#ifdef LIGHTMAP_ON
+            #ifdef LIGHTMAP_ON
 			float4 unity_LightmapFade;
-			#endif
-			fixed4 unity_Ambient;
-			#ifdef TESSELLATION_ON
+            #endif
+            fixed4 unity_Ambient;
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			uniform sampler2D _MainTex;
-			uniform float4 _Color;
-			uniform sampler2D _BumpMap;
-			uniform float _BumpScale;
-			uniform sampler2D _EmissionMap;
-			uniform float _Metallic;
-			uniform float _Smoothness;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
-				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
+            #endif
+            uniform sampler2D _MainTex;
+            uniform float4 _Color;
+            uniform sampler2D _BumpMap;
+            uniform float _BumpScale;
+            uniform sampler2D _EmissionMap;
+            uniform float _Metallic;
+            uniform float _Smoothness;
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
+                #define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
+                #define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
+                #define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
+                #define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Band)
+                #define _Band_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
+                #define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
+                #define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
+                #define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
+                #define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
-	
-			float3 HSVToRGB( float3 c )
-			{
-				float4 K = float4( 1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0 );
-				float3 p = abs( frac( c.xxx + K.xyz ) * 6.0 - K.www );
-				return c.z * lerp( K.xxx, saturate( p - K.xxx ), c.y );
-			}
-			
-			float3 RGBToHSV(float3 c)
-			{
-				float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-				float4 p = lerp( float4( c.bg, K.wz ), float4( c.gb, K.xy ), step( c.b, c.g ) );
-				float4 q = lerp( float4( p.xyw, c.r ), float4( c.r, p.yzx ), step( p.x, c.r ) );
-				float d = q.x - min( q.w, q.y );
-				float e = 1.0e-10;
-				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-			}
-			inline float AudioLinkLerp3_g6( int Band, float Delay )
-			{
-				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
-			}
-			
 
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+            float3 HSVToRGB(float3 c)
+            {
+                float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                float3 p = abs(frac(c.xxx + K.xyz) * 6.0 - K.www);
+                return c.z * lerp(K.xxx, saturate(p - K.xxx), c.y);
+            }
 
-				o.ase_texcoord8.xy = v.ase_texcoord.xy;
-				
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord8.zw = 0;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            float3 RGBToHSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            inline float AudioLinkLerp3_g6(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.ase_texcoord8.xy = v.ase_texcoord.xy;
+
+                //setting value to unused interpolator channels and avoid initialization warnings
+                o.ase_texcoord8.zw = 0;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				o.pos = UnityObjectToClipPos(v.vertex);
-				float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
-				fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
-				fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
-				fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
-				fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
-				o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
-				o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
-				o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
+                o.pos = UnityObjectToClipPos(v.vertex);
+                float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
+                fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
+                fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
+                fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
+                fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
+                o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
+                o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
+                o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
 
-				#ifdef DYNAMICLIGHTMAP_ON
+                #ifdef DYNAMICLIGHTMAP_ON
 					o.lmap.zw = v.texcoord2.xy * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
-				#else
-					o.lmap.zw = 0;
-				#endif
-				#ifdef LIGHTMAP_ON
+                #else
+                o.lmap.zw = 0;
+                #endif
+                #ifdef LIGHTMAP_ON
 					o.lmap.xy = v.texcoord1.xy * unity_LightmapST.xy + unity_LightmapST.zw;
-					#ifdef DIRLIGHTMAP_OFF
+                #ifdef DIRLIGHTMAP_OFF
 						o.lmapFadePos.xyz = (mul(unity_ObjectToWorld, v.vertex).xyz - unity_ShadowFadeCenterAndType.xyz) * unity_ShadowFadeCenterAndType.w;
 						o.lmapFadePos.w = (-UnityObjectToViewPos(v.vertex).z) * (1.0 - unity_ShadowFadeCenterAndType.w);
-					#endif
-				#else
-					o.lmap.xy = 0;
-					#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #endif
+                #else
+                o.lmap.xy = 0;
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 						o.sh = 0;
 						o.sh = ShadeSHPerVertex (worldNormal, o.sh);
-					#endif
-				#endif
-				return o;
-			}
+                #endif
+                #endif
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -1390,15 +1428,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -1423,334 +1461,350 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
 				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
-				#if defined(ASE_PHONG_TESSELLATION)
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
 
-			void frag (v2f IN 
-				, out half4 outGBuffer0 : SV_Target0
-				, out half4 outGBuffer1 : SV_Target1
-				, out half4 outGBuffer2 : SV_Target2
-				, out half4 outEmission : SV_Target3
-				#if defined(SHADOWS_SHADOWMASK) && (UNITY_ALLOWED_MRT_COUNT > 4)
+            void frag(v2f IN
+                                                                 , out half4 outGBuffer0 : SV_Target0
+                                                                 , out half4 outGBuffer1 : SV_Target1
+                                                                 , out half4 outGBuffer2 : SV_Target2
+                                                                 , out half4 outEmission : SV_Target3
+                                                                 #if defined(SHADOWS_SHADOWMASK) && (UNITY_ALLOWED_MRT_COUNT > 4)
 				, out half4 outShadowMask : SV_Target4
-				#endif
-				#ifdef _DEPTHOFFSET_ON
+                                                                 #endif
+                                                                 #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-			) 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
+                                                                 #endif
+            )
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
 
-				#ifdef LOD_FADE_CROSSFADE
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
-				float3 WorldTangent = float3(IN.tSpace0.x,IN.tSpace1.x,IN.tSpace2.x);
-				float3 WorldBiTangent = float3(IN.tSpace0.y,IN.tSpace1.y,IN.tSpace2.y);
-				float3 WorldNormal = float3(IN.tSpace0.z,IN.tSpace1.z,IN.tSpace2.z);
-				float3 worldPos = float3(IN.tSpace0.w,IN.tSpace1.w,IN.tSpace2.w);
-				float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
-				half atten = 1;
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
+                float3 WorldTangent = float3(IN.tSpace0.x, IN.tSpace1.x, IN.tSpace2.x);
+                float3 WorldBiTangent = float3(IN.tSpace0.y, IN.tSpace1.y, IN.tSpace2.y);
+                float3 WorldNormal = float3(IN.tSpace0.z, IN.tSpace1.z, IN.tSpace2.z);
+                float3 worldPos = float3(IN.tSpace0.w, IN.tSpace1.w, IN.tSpace2.w);
+                float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
+                half atten = 1;
 
-				float2 texCoord6 = IN.ase_texcoord8.xy * float2( 1,1 ) + float2( 0,0 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2D( _MainTex, texCoord6 ) * _Color ).rgb );
-				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
-				float hueShift33 = _AudioHueShift_Instance;
-				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g6 = (int)_Band_Instance;
-				float2 texCoord50 = IN.ase_texcoord8.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g4 = texCoord50;
-				float temp_output_5_0_g4 = ( break6_g4.x - 0.5 );
-				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g4 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g4 = cos( temp_output_2_0_g4 );
-				float temp_output_8_0_g4 = sin( temp_output_2_0_g4 );
-				float temp_output_20_0_g4 = ( 1.0 / ( abs( temp_output_3_0_g4 ) + abs( temp_output_8_0_g4 ) ) );
-				float temp_output_7_0_g4 = ( break6_g4.y - 0.5 );
-				float2 appendResult16_g4 = (float2(( ( ( temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) + ( temp_output_7_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) - ( temp_output_5_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 )));
-				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
-				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g6 = ( ( (_Delay_Instance + (( appendResult16_g4.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6( Band3_g6 , Delay3_g6 );
-				float temp_output_96_0 = localAudioLinkLerp3_g6;
-				float amplitude36 = temp_output_96_0;
-				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
-				
-				float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
-				float2 uv_BumpMap = IN.ase_texcoord8.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
-				
-				float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
-				float2 uv_EmissionMap = IN.ase_texcoord8.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
-				float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
-				float3 hsvTorgb40 = RGBToHSV( ( tex2D( _EmissionMap, uv_EmissionMap ) * _EmissionColor_Instance * temp_output_96_0 ).rgb );
-				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
-				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
-				
-				o.Albedo = hsvTorgb39;
-				o.Normal = ( UnpackNormal( tex2D( _BumpMap, uv_BumpMap ) ) * _BumpScale );
-				o.Emission = ( hsvTorgb45 * _Emission_Instance );
-				#if defined(_SPECULAR_SETUP)
+                float2 texCoord6 = IN.ase_texcoord8.xy * float2(1, 1) + float2(0, 0);
+                float3 hsvTorgb32 = RGBToHSV((tex2D(_MainTex, texCoord6) * _Color).rgb);
+                float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
+                float hueShift33 = _AudioHueShift_Instance;
+                float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
+                int Band3_g6 = (int)_Band_Instance;
+                float2 texCoord50 = IN.ase_texcoord8.xy * float2(1, 1) + float2(0, 0);
+                float2 break6_g4 = texCoord50;
+                float temp_output_5_0_g4 = (break6_g4.x - 0.5);
+                float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
+                float temp_output_2_0_g4 = radians(_PulseRotation_Instance);
+                float temp_output_3_0_g4 = cos(temp_output_2_0_g4);
+                float temp_output_8_0_g4 = sin(temp_output_2_0_g4);
+                float temp_output_20_0_g4 = (1.0 / (abs(temp_output_3_0_g4) + abs(temp_output_8_0_g4)));
+                float temp_output_7_0_g4 = (break6_g4.y - 0.5);
+                float2 appendResult16_g4 = (float2(
+                    (((temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4) + (temp_output_7_0_g4 *
+                        temp_output_8_0_g4 * temp_output_20_0_g4)) + 0.5),
+                    (((temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4) - (temp_output_5_0_g4 *
+                        temp_output_8_0_g4 * temp_output_20_0_g4)) + 0.5)));
+                float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
+                float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
+                float Delay3_g6 = (((_Delay_Instance + ((appendResult16_g4.x * _Pulse_Instance) - 0.0) * (1.0 -
+                    _Delay_Instance) / (1.0 - 0.0)) % 1.0) * 128.0);
+                float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6(Band3_g6, Delay3_g6);
+                float temp_output_96_0 = localAudioLinkLerp3_g6;
+                float amplitude36 = temp_output_96_0;
+                float3 hsvTorgb39 = HSVToRGB(float3((hsvTorgb32.x + (hueShift33 * amplitude36)), hsvTorgb32.y,
+                                        hsvTorgb32.z));
+
+                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
+                float2 uv_BumpMap = IN.ase_texcoord8.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
+
+                float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
+                float2 uv_EmissionMap = IN.ase_texcoord8.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
+                float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
+                float3 hsvTorgb40 = RGBToHSV(
+                    (tex2D(_EmissionMap, uv_EmissionMap) * _EmissionColor_Instance * temp_output_96_0).rgb);
+                float3 hsvTorgb45 = HSVToRGB(float3((hsvTorgb40.x + (hueShift33 * amplitude36)), hsvTorgb40.y,
+                    hsvTorgb40.z));
+                float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
+
+                o.Albedo = hsvTorgb39;
+                o.Normal = (UnpackNormal(tex2D(_BumpMap, uv_BumpMap)) * _BumpScale);
+                o.Emission = (hsvTorgb45 * _Emission_Instance);
+                #if defined(_SPECULAR_SETUP)
 					o.Specular = fixed3( 0, 0, 0 );
-				#else
-					o.Metallic = _Metallic;
-				#endif
-				o.Smoothness = _Smoothness;
-				o.Occlusion = 1;
-				o.Alpha = 1;
-				float AlphaClipThreshold = 0.5;
-				float3 BakedGI = 0;
+                #else
+                o.Metallic = _Metallic;
+                #endif
+                o.Smoothness = _Smoothness;
+                o.Occlusion = 1;
+                o.Alpha = 1;
+                float AlphaClipThreshold = 0.5;
+                float3 BakedGI = 0;
 
-				#ifdef _ALPHATEST_ON
+                #ifdef _ALPHATEST_ON
 					clip( o.Alpha - AlphaClipThreshold );
-				#endif
+                #endif
 
-				#ifdef _DEPTHOFFSET_ON
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				#ifndef USING_DIRECTIONAL_LIGHT
-					fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
-				#else
+                #ifndef USING_DIRECTIONAL_LIGHT
+                fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
+                #else
 					fixed3 lightDir = _WorldSpaceLightPos0.xyz;
-				#endif
+                #endif
 
-				float3 worldN;
-				worldN.x = dot(IN.tSpace0.xyz, o.Normal);
-				worldN.y = dot(IN.tSpace1.xyz, o.Normal);
-				worldN.z = dot(IN.tSpace2.xyz, o.Normal);
-				worldN = normalize(worldN);
-				o.Normal = worldN;
+                float3 worldN;
+                worldN.x = dot(IN.tSpace0.xyz, o.Normal);
+                worldN.y = dot(IN.tSpace1.xyz, o.Normal);
+                worldN.z = dot(IN.tSpace2.xyz, o.Normal);
+                worldN = normalize(worldN);
+                o.Normal = worldN;
 
-				UnityGI gi;
-				UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
-				gi.indirect.diffuse = 0;
-				gi.indirect.specular = 0;
-				gi.light.color = 0;
-				gi.light.dir = half3(0,1,0);
+                UnityGI gi;
+                UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
+                gi.indirect.diffuse = 0;
+                gi.indirect.specular = 0;
+                gi.light.color = 0;
+                gi.light.dir = half3(0, 1, 0);
 
-				UnityGIInput giInput;
-				UNITY_INITIALIZE_OUTPUT(UnityGIInput, giInput);
-				giInput.light = gi.light;
-				giInput.worldPos = worldPos;
-				giInput.worldViewDir = worldViewDir;
-				giInput.atten = atten;
-				#if defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)
+                UnityGIInput giInput;
+                UNITY_INITIALIZE_OUTPUT(UnityGIInput, giInput);
+                giInput.light = gi.light;
+                giInput.worldPos = worldPos;
+                giInput.worldViewDir = worldViewDir;
+                giInput.atten = atten;
+                #if defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)
 					giInput.lightmapUV = IN.lmap;
-				#else
-					giInput.lightmapUV = 0.0;
-				#endif
-				#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #else
+                giInput.lightmapUV = 0.0;
+                #endif
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 					giInput.ambient = IN.sh;
-				#else
-					giInput.ambient.rgb = 0.0;
-				#endif
-				giInput.probeHDR[0] = unity_SpecCube0_HDR;
-				giInput.probeHDR[1] = unity_SpecCube1_HDR;
-				#if defined(UNITY_SPECCUBE_BLENDING) || defined(UNITY_SPECCUBE_BOX_PROJECTION)
+                #else
+                giInput.ambient.rgb = 0.0;
+                #endif
+                giInput.probeHDR[0] = unity_SpecCube0_HDR;
+                giInput.probeHDR[1] = unity_SpecCube1_HDR;
+                #if defined(UNITY_SPECCUBE_BLENDING) || defined(UNITY_SPECCUBE_BOX_PROJECTION)
 					giInput.boxMin[0] = unity_SpecCube0_BoxMin;
-				#endif
-				#ifdef UNITY_SPECCUBE_BOX_PROJECTION
+                #endif
+                #ifdef UNITY_SPECCUBE_BOX_PROJECTION
 					giInput.boxMax[0] = unity_SpecCube0_BoxMax;
 					giInput.probePosition[0] = unity_SpecCube0_ProbePosition;
 					giInput.boxMax[1] = unity_SpecCube1_BoxMax;
 					giInput.boxMin[1] = unity_SpecCube1_BoxMin;
 					giInput.probePosition[1] = unity_SpecCube1_ProbePosition;
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					LightingStandardSpecular_GI( o, giInput, gi );
-				#else
-					LightingStandard_GI( o, giInput, gi );
-				#endif
+                #else
+                LightingStandard_GI(o, giInput, gi);
+                #endif
 
-				#ifdef ASE_BAKEDGI
+                #ifdef ASE_BAKEDGI
 					gi.indirect.diffuse = BakedGI;
-				#endif
+                #endif
 
-				#if UNITY_SHOULD_SAMPLE_SH && !defined(LIGHTMAP_ON) && defined(ASE_NO_AMBIENT)
+                #if UNITY_SHOULD_SAMPLE_SH && !defined(LIGHTMAP_ON) && defined(ASE_NO_AMBIENT)
 					gi.indirect.diffuse = 0;
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					outEmission = LightingStandardSpecular_Deferred( o, worldViewDir, gi, outGBuffer0, outGBuffer1, outGBuffer2 );
-				#else
-					outEmission = LightingStandard_Deferred( o, worldViewDir, gi, outGBuffer0, outGBuffer1, outGBuffer2 );
-				#endif
+                #else
+                outEmission = LightingStandard_Deferred(o, worldViewDir, gi, outGBuffer0, outGBuffer1, outGBuffer2);
+                #endif
 
-				#if defined(SHADOWS_SHADOWMASK) && (UNITY_ALLOWED_MRT_COUNT > 4)
+                #if defined(SHADOWS_SHADOWMASK) && (UNITY_ALLOWED_MRT_COUNT > 4)
 					outShadowMask = UnityGetRawBakedOcclusions (IN.lmap.xy, float3(0, 0, 0));
-				#endif
-				#ifndef UNITY_HDR_ON
-					outEmission.rgb = exp2(-outEmission.rgb);
-				#endif
-			}
-			ENDCG
-		}
+                #endif
+                #ifndef UNITY_HDR_ON
+                outEmission.rgb = exp2(-outEmission.rgb);
+                #endif
+            }
+            ENDCG
+        }
 
-		
-		Pass
-		{
-			
-			Name "Meta"
-			Tags { "LightMode"="Meta" }
-			Cull Off
 
-			CGPROGRAM
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
+        Pass
+        {
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
-			#pragma shader_feature EDITOR_VISUALIZATION
-			#ifndef UNITY_PASS_META
-				#define UNITY_PASS_META
-			#endif
-			#include "HLSLSupport.cginc"
-			#if !defined( UNITY_INSTANCED_LOD_FADE )
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#if !defined( UNITY_INSTANCED_SH )
-				#define UNITY_INSTANCED_SH
-			#endif
-			#if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "UnityMetaPass.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            Name "Meta"
+            Tags
+            {
+                "LightMode"="Meta"
+            }
+            Cull Off
 
-			#pragma multi_compile_instancing
+            CGPROGRAM
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
 
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
-			struct v2f {
-				#if UNITY_VERSION >= 201810
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
+            #pragma shader_feature EDITOR_VISUALIZATION
+            #ifndef UNITY_PASS_META
+            #define UNITY_PASS_META
+            #endif
+            #include "HLSLSupport.cginc"
+            #if !defined( UNITY_INSTANCED_LOD_FADE )
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #if !defined( UNITY_INSTANCED_SH )
+            #define UNITY_INSTANCED_SH
+            #endif
+            #if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "UnityMetaPass.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            #pragma multi_compile_instancing
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+                float4 ase_texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                #if UNITY_VERSION >= 201810
 					UNITY_POSITION(pos);
-				#else
-					float4 pos : SV_POSITION;
-				#endif
-				#ifdef EDITOR_VISUALIZATION
+                #else
+                float4 pos : SV_POSITION;
+                #endif
+                #ifdef EDITOR_VISUALIZATION
 					float2 vizUV : TEXCOORD1;
 					float4 lightCoord : TEXCOORD2;
-				#endif
-				float4 ase_texcoord3 : TEXCOORD3;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+                #endif
+                float4 ase_texcoord3 : TEXCOORD3;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
 
-			#ifdef TESSELLATION_ON
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			uniform sampler2D _MainTex;
-			uniform float4 _Color;
-			uniform sampler2D _EmissionMap;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
-				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
+            #endif
+            uniform sampler2D _MainTex;
+            uniform float4 _Color;
+            uniform sampler2D _EmissionMap;
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
+                #define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
+                #define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
+                #define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Band)
+                #define _Band_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
+                #define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
+                #define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
+                #define _Delay_arr AudioLinkSurfaceAudioReactiveSurface
+                UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
+                #define _Emission_arr AudioLinkSurfaceAudioReactiveSurface
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
-	
-			float3 HSVToRGB( float3 c )
-			{
-				float4 K = float4( 1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0 );
-				float3 p = abs( frac( c.xxx + K.xyz ) * 6.0 - K.www );
-				return c.z * lerp( K.xxx, saturate( p - K.xxx ), c.y );
-			}
-			
-			float3 RGBToHSV(float3 c)
-			{
-				float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-				float4 p = lerp( float4( c.bg, K.wz ), float4( c.gb, K.xy ), step( c.b, c.g ) );
-				float4 q = lerp( float4( p.xyw, c.r ), float4( c.r, p.yzx ), step( p.x, c.r ) );
-				float d = q.x - min( q.w, q.y );
-				float e = 1.0e-10;
-				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-			}
-			inline float AudioLinkLerp3_g6( int Band, float Delay )
-			{
-				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
-			}
-			
 
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+            float3 HSVToRGB(float3 c)
+            {
+                float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                float3 p = abs(frac(c.xxx + K.xyz) * 6.0 - K.www);
+                return c.z * lerp(K.xxx, saturate(p - K.xxx), c.y);
+            }
 
-				o.ase_texcoord3.xy = v.ase_texcoord.xy;
-				
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord3.zw = 0;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            float3 RGBToHSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            inline float AudioLinkLerp3_g6(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                    UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.ase_texcoord3.xy = v.ase_texcoord.xy;
+
+                //setting value to unused interpolator channels and avoid initialization warnings
+                o.ase_texcoord3.zw = 0;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				#ifdef EDITOR_VISUALIZATION
+                #ifdef EDITOR_VISUALIZATION
 					o.vizUV = 0;
 					o.lightCoord = 0;
 					if (unity_VisualizationMode == EDITORVIZ_TEXTURE)
@@ -1760,14 +1814,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 						o.vizUV = v.texcoord1.xy * unity_LightmapST.xy + unity_LightmapST.zw;
 						o.lightCoord = mul(unity_EditorViz_WorldToLight, mul(unity_ObjectToWorld, float4(v.vertex.xyz, 1)));
 					}
-				#endif
+                #endif
 
-				o.pos = UnityMetaVertexPosition(v.vertex, v.texcoord1.xy, v.texcoord2.xy, unity_LightmapST, unity_DynamicLightmapST);
+                o.pos = UnityMetaVertexPosition(v.vertex, v.texcoord1.xy, v.texcoord2.xy, unity_LightmapST,
+                                                       unity_DynamicLightmapST);
 
-				return o;
-			}
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -1806,15 +1861,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -1839,204 +1894,217 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
 				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
-				#if defined(ASE_PHONG_TESSELLATION)
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
 
-			fixed4 frag (v2f IN 
-				#ifdef _DEPTHOFFSET_ON
+            fixed4 frag(v2f IN
+                #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-				) : SV_Target 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
-				
-				#ifdef LOD_FADE_CROSSFADE
+                #endif
+            ) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
+
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
-				
-				float2 texCoord6 = IN.ase_texcoord3.xy * float2( 1,1 ) + float2( 0,0 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2D( _MainTex, texCoord6 ) * _Color ).rgb );
-				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
-				float hueShift33 = _AudioHueShift_Instance;
-				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g6 = (int)_Band_Instance;
-				float2 texCoord50 = IN.ase_texcoord3.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g4 = texCoord50;
-				float temp_output_5_0_g4 = ( break6_g4.x - 0.5 );
-				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g4 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g4 = cos( temp_output_2_0_g4 );
-				float temp_output_8_0_g4 = sin( temp_output_2_0_g4 );
-				float temp_output_20_0_g4 = ( 1.0 / ( abs( temp_output_3_0_g4 ) + abs( temp_output_8_0_g4 ) ) );
-				float temp_output_7_0_g4 = ( break6_g4.y - 0.5 );
-				float2 appendResult16_g4 = (float2(( ( ( temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) + ( temp_output_7_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4 ) - ( temp_output_5_0_g4 * temp_output_8_0_g4 * temp_output_20_0_g4 ) ) + 0.5 )));
-				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
-				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g6 = ( ( (_Delay_Instance + (( appendResult16_g4.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6( Band3_g6 , Delay3_g6 );
-				float temp_output_96_0 = localAudioLinkLerp3_g6;
-				float amplitude36 = temp_output_96_0;
-				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
-				
-				float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
-				float2 uv_EmissionMap = IN.ase_texcoord3.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
-				float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
-				float3 hsvTorgb40 = RGBToHSV( ( tex2D( _EmissionMap, uv_EmissionMap ) * _EmissionColor_Instance * temp_output_96_0 ).rgb );
-				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
-				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
-				
-				o.Albedo = hsvTorgb39;
-				o.Normal = fixed3( 0, 0, 1 );
-				o.Emission = ( hsvTorgb45 * _Emission_Instance );
-				o.Alpha = 1;
-				float AlphaClipThreshold = 0.5;
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
 
-				#ifdef _ALPHATEST_ON
+                float2 texCoord6 = IN.ase_texcoord3.xy * float2(1, 1) + float2(0, 0);
+                float3 hsvTorgb32 = RGBToHSV((tex2D(_MainTex, texCoord6) * _Color).rgb);
+                float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
+                float hueShift33 = _AudioHueShift_Instance;
+                float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
+                int Band3_g6 = (int)_Band_Instance;
+                float2 texCoord50 = IN.ase_texcoord3.xy * float2(1, 1) + float2(0, 0);
+                float2 break6_g4 = texCoord50;
+                float temp_output_5_0_g4 = (break6_g4.x - 0.5);
+                float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
+                float temp_output_2_0_g4 = radians(_PulseRotation_Instance);
+                float temp_output_3_0_g4 = cos(temp_output_2_0_g4);
+                float temp_output_8_0_g4 = sin(temp_output_2_0_g4);
+                float temp_output_20_0_g4 = (1.0 / (abs(temp_output_3_0_g4) + abs(temp_output_8_0_g4)));
+                float temp_output_7_0_g4 = (break6_g4.y - 0.5);
+                float2 appendResult16_g4 = (float2(
+                    (((temp_output_5_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4) + (temp_output_7_0_g4 *
+                        temp_output_8_0_g4 * temp_output_20_0_g4)) + 0.5),
+                    (((temp_output_7_0_g4 * temp_output_3_0_g4 * temp_output_20_0_g4) - (temp_output_5_0_g4 *
+                        temp_output_8_0_g4 * temp_output_20_0_g4)) + 0.5)));
+                float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
+                float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
+                float Delay3_g6 = (((_Delay_Instance + ((appendResult16_g4.x * _Pulse_Instance) - 0.0) * (1.0 -
+                    _Delay_Instance) / (1.0 - 0.0)) % 1.0) * 128.0);
+                float localAudioLinkLerp3_g6 = AudioLinkLerp3_g6(Band3_g6, Delay3_g6);
+                float temp_output_96_0 = localAudioLinkLerp3_g6;
+                float amplitude36 = temp_output_96_0;
+                float3 hsvTorgb39 = HSVToRGB(float3((hsvTorgb32.x + (hueShift33 * amplitude36)), hsvTorgb32.y,
+                                                    hsvTorgb32.z));
+
+                float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
+                float2 uv_EmissionMap = IN.ase_texcoord3.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
+                float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
+                float3 hsvTorgb40 = RGBToHSV(
+                    (tex2D(_EmissionMap, uv_EmissionMap) * _EmissionColor_Instance * temp_output_96_0).rgb);
+                float3 hsvTorgb45 = HSVToRGB(float3((hsvTorgb40.x + (hueShift33 * amplitude36)), hsvTorgb40.y,
+                                                    hsvTorgb40.z));
+                float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
+
+                o.Albedo = hsvTorgb39;
+                o.Normal = fixed3(0, 0, 1);
+                o.Emission = (hsvTorgb45 * _Emission_Instance);
+                o.Alpha = 1;
+                float AlphaClipThreshold = 0.5;
+
+                #ifdef _ALPHATEST_ON
 					clip( o.Alpha - AlphaClipThreshold );
-				#endif
+                #endif
 
-				#ifdef _DEPTHOFFSET_ON
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				UnityMetaInput metaIN;
-				UNITY_INITIALIZE_OUTPUT(UnityMetaInput, metaIN);
-				metaIN.Albedo = o.Albedo;
-				metaIN.Emission = o.Emission;
-				#ifdef EDITOR_VISUALIZATION
+                UnityMetaInput metaIN;
+                UNITY_INITIALIZE_OUTPUT(UnityMetaInput, metaIN);
+                metaIN.Albedo = o.Albedo;
+                metaIN.Emission = o.Emission;
+                #ifdef EDITOR_VISUALIZATION
 					metaIN.VizUV = IN.vizUV;
 					metaIN.LightCoord = IN.lightCoord;
-				#endif
-				return UnityMetaFragment(metaIN);
-			}
-			ENDCG
-		}
+                #endif
+                return UnityMetaFragment(metaIN);
+            }
+            ENDCG
+        }
 
-		
-		Pass
-		{
-			
-			Name "ShadowCaster"
-			Tags { "LightMode"="ShadowCaster" }
-			ZWrite On
-			ZTest LEqual
-			AlphaToMask Off
 
-			CGPROGRAM
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
+        Pass
+        {
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
-			#pragma multi_compile_shadowcaster
-			#ifndef UNITY_PASS_SHADOWCASTER
-				#define UNITY_PASS_SHADOWCASTER
-			#endif
-			#include "HLSLSupport.cginc"
-			#ifndef UNITY_INSTANCED_LOD_FADE
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#ifndef UNITY_INSTANCED_SH
-				#define UNITY_INSTANCED_SH
-			#endif
-			#ifndef UNITY_INSTANCED_LIGHTMAPSTS
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#if ( SHADER_API_D3D11 || SHADER_API_GLCORE || SHADER_API_GLES || SHADER_API_GLES3 || SHADER_API_METAL || SHADER_API_VULKAN )
-				#define CAN_SKIP_VPOS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            Name "ShadowCaster"
+            Tags
+            {
+                "LightMode"="ShadowCaster"
+            }
+            ZWrite On
+            ZTest LEqual
+            AlphaToMask Off
 
-			
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
+            CGPROGRAM
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
 
-			struct v2f {
-				V2F_SHADOW_CASTER;
-				
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
+            #pragma multi_compile_shadowcaster
+            #ifndef UNITY_PASS_SHADOWCASTER
+            #define UNITY_PASS_SHADOWCASTER
+            #endif
+            #include "HLSLSupport.cginc"
+            #ifndef UNITY_INSTANCED_LOD_FADE
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #ifndef UNITY_INSTANCED_SH
+            #define UNITY_INSTANCED_SH
+            #endif
+            #ifndef UNITY_INSTANCED_LIGHTMAPSTS
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #if ( SHADER_API_D3D11 || SHADER_API_GLCORE || SHADER_API_GLES || SHADER_API_GLES3 || SHADER_API_METAL || SHADER_API_VULKAN )
+            #define CAN_SKIP_VPOS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
 
-			#ifdef UNITY_STANDARD_USE_DITHER_MASK
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                V2F_SHADOW_CASTER;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #ifdef UNITY_STANDARD_USE_DITHER_MASK
 				sampler3D _DitherMaskLOD;
-			#endif
-			#ifdef TESSELLATION_ON
+            #endif
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
+            #endif
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface)
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface)
 
-	
-			
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
-				
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                    UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
-				return o;
-			}
+                    TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -2044,7 +2112,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				float3 normal : NORMAL;
 				float4 texcoord1 : TEXCOORD1;
 				float4 texcoord2 : TEXCOORD2;
-				
+
 				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
@@ -2064,7 +2132,7 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				o.normal = v.normal;
 				o.texcoord1 = v.texcoord1;
 				o.texcoord2 = v.texcoord2;
-				
+
 				return o;
 			}
 
@@ -2074,15 +2142,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -2106,179 +2174,255 @@ Shader "AudioLink/Surface/AudioReactiveSurface"
 				o.normal = patch[0].normal * bary.x + patch[1].normal * bary.y + patch[2].normal * bary.z;
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
-				
-				#if defined(ASE_PHONG_TESSELLATION)
+
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
 
-			fixed4 frag (v2f IN 
-				#ifdef _DEPTHOFFSET_ON
+            fixed4 frag(v2f IN
+                #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-				#if !defined( CAN_SKIP_VPOS )
+                #endif
+                #if !defined( CAN_SKIP_VPOS )
 				, UNITY_VPOS_TYPE vpos : VPOS
-				#endif
-				) : SV_Target 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
+                #endif
+            ) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
 
-				#ifdef LOD_FADE_CROSSFADE
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
 
-				
-				o.Normal = fixed3( 0, 0, 1 );
-				o.Occlusion = 1;
-				o.Alpha = 1;
-				float AlphaClipThreshold = 0.5;
-				float AlphaClipThresholdShadow = 0.5;
 
-				#ifdef _ALPHATEST_SHADOW_ON
+                o.Normal = fixed3(0, 0, 1);
+                o.Occlusion = 1;
+                o.Alpha = 1;
+                float AlphaClipThreshold = 0.5;
+                float AlphaClipThresholdShadow = 0.5;
+
+                #ifdef _ALPHATEST_SHADOW_ON
 					if (unity_LightShadowBias.z != 0.0)
 						clip(o.Alpha - AlphaClipThresholdShadow);
-					#ifdef _ALPHATEST_ON
+                #ifdef _ALPHATEST_ON
 					else
 						clip(o.Alpha - AlphaClipThreshold);
-					#endif
-				#else
-					#ifdef _ALPHATEST_ON
+                #endif
+                #else
+                #ifdef _ALPHATEST_ON
 						clip(o.Alpha - AlphaClipThreshold);
-					#endif
-				#endif
+                #endif
+                #endif
 
-				#if defined( CAN_SKIP_VPOS )
-				float2 vpos = IN.pos;
-				#endif
+                #if defined( CAN_SKIP_VPOS )
+                float2 vpos = IN.pos;
+                #endif
 
-				#ifdef UNITY_STANDARD_USE_DITHER_MASK
+                #ifdef UNITY_STANDARD_USE_DITHER_MASK
 					half alphaRef = tex3D(_DitherMaskLOD, float3(vpos.xy*0.25,o.Alpha*0.9375)).a;
 					clip(alphaRef - 0.01);
-				#endif
+                #endif
 
-				#ifdef _DEPTHOFFSET_ON
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				SHADOW_CASTER_FRAGMENT(IN)
-			}
-			ENDCG
-		}
-		
-	}
-	CustomEditor "ASEMaterialInspector"
-	
-	
+                SHADOW_CASTER_FRAGMENT(IN)
+            }
+            ENDCG
+        }
+
+        // DepthOnly pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode"="DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #pragma multi_compile_instancing
+            #pragma target 3.0
+            #pragma prefer_hlslcc gles
+            #pragma exclude_renderers d3d11_9x
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            #define _ALPHATEST_ON 1
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            uniform sampler2D _MainTex;
+            uniform float _Cutoff;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.texcoord = v.texcoord;
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_TARGET
+            {
+                UNITY_SETUP_INSTANCE_ID(i);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+
+                #ifdef LOD_FADE_CROSSFADE
+            UNITY_APPLY_DITHER_CROSSFADE(i.pos.xy);
+                #endif
+
+                float4 tex = tex2D(_MainTex, i.texcoord);
+
+                #ifdef _ALPHATEST_ON
+                clip(tex.a - _Cutoff);
+                #endif
+
+                return 0;
+            }
+            ENDHLSL
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode"="DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #pragma multi_compile_instancing
+            #pragma target 3.0
+            #pragma prefer_hlslcc gles
+            #pragma exclude_renderers d3d11_9x
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            #define _ALPHATEST_ON 1
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float4 tangent : TANGENT;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                float3 normal : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            uniform sampler2D _MainTex;
+            uniform sampler2D _BumpMap;
+            uniform float _BumpScale;
+            uniform float _Cutoff;
+
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.texcoord = v.texcoord;
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_TARGET
+            {
+                UNITY_SETUP_INSTANCE_ID(i);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+
+                #ifdef LOD_FADE_CROSSFADE
+                UNITY_APPLY_DITHER_CROSSFADE(i.pos.xy);
+                #endif
+
+                float4 tex = tex2D(_MainTex, i.texcoord);
+
+                #ifdef _ALPHATEST_ON
+                clip(tex.a - _Cutoff);
+                #endif
+
+                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(
+                    AudioLinkSurfaceAudioReactiveSurface_Cutout, _BumpMap_ST);
+                float2 uv_BumpMap = i.texcoord * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
+
+                float3 normalTS = UnpackNormal(tex2D(_BumpMap, uv_BumpMap));
+                normalTS.xy *= _BumpScale;
+                normalTS.z = sqrt(1.0 - saturate(dot(normalTS.xy, normalTS.xy)));
+
+                float3 normalWS = normalize(normalTS);
+
+                // Encode normal and depth
+                return float4(normalWS * 0.5 + 0.5, 0);
+            }
+            ENDHLSL
+        }
+    }
 }
-/*ASEBEGIN
-Version=18908
-3114.4;81.6;2712;1462;2899.47;881.0705;1.515001;True;False
-Node;AmplifyShaderEditor.RangedFloatNode;31;-1390.638,-584.899;Inherit;False;InstancedProperty;_AudioHueShift;Audio Hue Shift;12;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;2;-955,-202.5;Inherit;False;Property;_Color;Color;1;0;Create;True;0;0;0;False;0;False;0.4980392,0.4980392,0.4980392,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.GetLocalVarNode;34;-366.2949,-141.8591;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SamplerNode;9;-936,-2;Inherit;True;Property;_BumpMap;Normal Map;4;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;bump;Auto;True;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;5;-597,-280;Inherit;False;2;2;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;1;COLOR;0
-Node;AmplifyShaderEditor.RangedFloatNode;12;261.2,1021.201;Inherit;False;Property;_Smoothness;Smoothness;3;0;Create;True;0;0;0;False;0;False;0.5;0.5;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.TextureCoordinatesNode;50;-2385.262,732.5444;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.FunctionNode;69;-1917.486,737.521;Inherit;False;RotateUVFill;-1;;4;459952d587cbfe742a7e7f4a8a0a4169;0;2;1;FLOAT2;0,0;False;2;FLOAT;0;False;1;FLOAT2;0
-Node;AmplifyShaderEditor.RegisterLocalVarNode;33;-1046.295,-583.8591;Inherit;False;hueShift;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;10;-812,202;Inherit;False;Property;_BumpScale;Normal Scale;5;0;Create;False;0;0;0;False;0;False;1;1;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.BreakToComponentsNode;78;-1616.565,796.2052;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
-Node;AmplifyShaderEditor.FunctionNode;96;-961.7287,821.9091;Inherit;False;4BandAmplitudeLerp;-1;;6;3cf4b6e83381a9a4f84f8cf857bc3af5;0;2;2;INT;0;False;4;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleAddOpNode;44;70.29944,482.272;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.GetLocalVarNode;37;-372.7727,-36.59692;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;38;-152.7727,-73.59692;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;47;534.9175,735.4701;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.FunctionNode;93;-1410.24,873.1649;Inherit;False;BandPulse;-1;;7;c478702160369ce4480fa2fb6d734ffa;0;3;1;FLOAT;0;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RadiansOpNode;51;-2083.566,860.3765;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RGBToHSVNode;32;-372.2949,-372.8591;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.TextureCoordinatesNode;6;-1357,-367;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;43;-91.17834,730.5342;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;98;-1137.932,882.2094;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;128;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RegisterLocalVarNode;36;-599.8431,921.3793;Inherit;False;amplitude;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.HSVToRGBNode;39;191.2273,-167.5969;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.SimpleAddOpNode;35;8.705078,-321.8591;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SamplerNode;14;-989.8879,298.6613;Inherit;True;Property;_EmissionMap;Emission Map;6;0;Create;True;0;0;0;False;0;False;-1;None;None;True;0;False;gray;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.HSVToRGBNode;45;252.8217,636.5342;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.GetLocalVarNode;42;-304.7005,662.272;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;11;-502,92;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;15;-528.8879,636.6613;Inherit;False;3;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;0;False;1;COLOR;0
-Node;AmplifyShaderEditor.RangedFloatNode;49;-2381.913,871.5845;Inherit;False;InstancedProperty;_PulseRotation;Pulse Rotation;13;0;Create;True;0;0;0;False;0;False;0;0;0;360;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;57;-1752.023,925.6572;Inherit;False;InstancedProperty;_Pulse;Pulse;11;1;[Header];Create;True;1;Pulse Across UVs;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;18;-1751.102,1027.495;Inherit;False;InstancedProperty;_Delay;Delay;10;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;17;-1434.696,642.8046;Inherit;False;InstancedProperty;_Band;Band;9;2;[Header];[IntRange];Create;True;1;Audio Section;0;0;False;0;False;0;0;0;3;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;46;255.5175,800.3702;Inherit;False;InstancedProperty;_Emission;Emission Scale;8;0;Create;False;0;0;0;False;0;False;1;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;13;258.2,923.202;Inherit;False;Property;_Metallic;Metallic;2;0;Create;True;0;0;0;False;0;False;0;0.5;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RGBToHSVNode;40;-310.7005,431.272;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.GetLocalVarNode;41;-311.1783,767.5342;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SamplerNode;4;-1039,-416;Inherit;True;Property;_MainTex;Albedo;0;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;white;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.ColorNode;3;-935.8119,580.942;Inherit;False;InstancedProperty;_EmissionColor;Emission Color;7;1;[HDR];Create;True;0;0;0;False;0;False;0,0,0,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;85;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Deferred;0;3;Deferred;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Deferred;True;2;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;86;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Meta;0;4;Meta;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Meta;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;82;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ExtraPrePass;0;0;ExtraPrePass;6;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;True;True;0;False;-1;0;False;-1;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;87;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ShadowCaster;0;5;ShadowCaster;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;False;-1;True;3;False;-1;False;True;1;LightMode=ShadowCaster;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;84;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;10;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ForwardAdd;0;2;ForwardAdd;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;4;1;False;-1;1;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;True;1;LightMode=ForwardAdd;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;83;824,664;Float;False;True;-1;2;ASEMaterialInspector;0;10;AudioLink/Surface/AudioReactiveSurface;f0be08cf82190c945883605df227bec5;True;ForwardBase;0;1;ForwardBase;18;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;40;Workflow,InvertActionOnDeselection;1;Surface;0;  Blend;0;  Refraction Model;0;  Dither Shadows;1;Two Sided;1;Deferred Pass;1;Transmission;0;  Transmission Shadow;0.5,False,-1;Translucency;0;  Translucency Strength;1,False,-1;  Normal Distortion;0.5,False,-1;  Scattering;2,False,-1;  Direct;0.9,False,-1;  Ambient;0.1,False,-1;  Shadow;0.5,False,-1;Cast Shadows;1;  Use Shadow Threshold;0;Receive Shadows;1;GPU Instancing;1;LOD CrossFade;1;Built-in Fog;1;Ambient Light;1;Meta Pass;1;Add Pass;1;Override Baked GI;0;Extra Pre Pass;0;Tessellation;0;  Phong;0;  Strength;0.5,False,-1;  Type;0;  Tess;16,False,-1;  Min;10,False,-1;  Max;25,False,-1;  Edge Length;16,False,-1;  Max Displacement;25,False,-1;Fwd Specular Highlights Toggle;0;Fwd Reflections Toggle;0;Disable Batching;0;Vertex Position,InvertActionOnDeselection;1;0;6;False;True;True;True;True;True;False;;False;0
-WireConnection;5;0;4;0
-WireConnection;5;1;2;0
-WireConnection;69;1;50;0
-WireConnection;69;2;51;0
-WireConnection;33;0;31;0
-WireConnection;78;0;69;0
-WireConnection;96;2;17;0
-WireConnection;96;4;98;0
-WireConnection;44;0;40;1
-WireConnection;44;1;43;0
-WireConnection;38;0;34;0
-WireConnection;38;1;37;0
-WireConnection;47;0;45;0
-WireConnection;47;1;46;0
-WireConnection;93;1;78;0
-WireConnection;93;2;57;0
-WireConnection;93;3;18;0
-WireConnection;51;0;49;0
-WireConnection;32;0;5;0
-WireConnection;43;0;42;0
-WireConnection;43;1;41;0
-WireConnection;98;0;93;0
-WireConnection;36;0;96;0
-WireConnection;39;0;35;0
-WireConnection;39;1;32;2
-WireConnection;39;2;32;3
-WireConnection;35;0;32;1
-WireConnection;35;1;38;0
-WireConnection;45;0;44;0
-WireConnection;45;1;40;2
-WireConnection;45;2;40;3
-WireConnection;11;0;9;0
-WireConnection;11;1;10;0
-WireConnection;15;0;14;0
-WireConnection;15;1;3;0
-WireConnection;15;2;96;0
-WireConnection;40;0;15;0
-WireConnection;4;1;6;0
-WireConnection;83;0;39;0
-WireConnection;83;1;11;0
-WireConnection;83;2;47;0
-WireConnection;83;4;13;0
-WireConnection;83;5;12;0
-ASEEND*/
-//CHKSM=EC822472A6313A32E5127FEC5369A7CEABC7478D

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface.shader.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface.shader.meta
@@ -1,9 +1,3 @@
 fileFormatVersion: 2
-guid: 75b202cd6c96bf144b1ad251052c51e7
-ShaderImporter:
-  externalObjects: {}
-  defaultTextures: []
-  nonModifiableTextures: []
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+guid: 712e462eff0245a58182829a43c9aa99
+timeCreated: 1747723783

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface_Cutout.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface_Cutout.shader
@@ -1,399 +1,390 @@
 // Upgrade NOTE: upgraded instancing buffer 'AudioLinkSurfaceAudioReactiveSurface_Cutout' to new syntax.
 
 // Made with Amplify Shader Editor
-// Available at the Unity Asset Store - http://u3d.as/y3X 
+// Available at the Unity Asset Store - http://u3d.as/y3X
 Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 {
-	Properties
-	{
-		_MainTex("Albedo", 2D) = "white" {}
-		_Cutoff("Cutoff", Float) = 0.5
-		_Color("Color", Color) = (0.4980392,0.4980392,0.4980392,1)
-		_Metallic("Metallic", Range( 0 , 1)) = 0
-		_Smoothness("Smoothness", Range( 0 , 1)) = 0.5
-		_BumpMap("Normal Map", 2D) = "bump" {}
-		_BumpScale("Normal Scale", Float) = 1
-		_EmissionMap("Emission Map", 2D) = "gray" {}
-		[HDR]_EmissionColor("Emission Color", Color) = (0,0,0,1)
-		_Emission("Emission Scale", Float) = 1
-		[Header(Audio Section)][IntRange]_Band("Band", Range( 0 , 3)) = 0
-		_Delay("Delay", Range( 0 , 1)) = 0
-		[Header(Pulse Across UVs)]_Pulse("Pulse", Range( 0 , 1)) = 0
-		_AudioHueShift("Audio Hue Shift", Float) = 0
-		_PulseRotation("Pulse Rotation", Range( 0 , 360)) = 0
-		[HideInInspector] _texcoord( "", 2D ) = "white" {}
+    Properties
+    {
+        _MainTex("Albedo", 2D) = "white" {}
+        _Cutoff("Cutoff", Float) = 0.5
+        _Color("Color", Color) = (0.4980392,0.4980392,0.4980392,1)
+        _Metallic("Metallic", Range( 0 , 1)) = 0
+        _Smoothness("Smoothness", Range( 0 , 1)) = 0.5
+        _BumpMap("Normal Map", 2D) = "bump" {}
+        _BumpScale("Normal Scale", Float) = 1
+        _EmissionMap("Emission Map", 2D) = "gray" {}
+        [HDR]_EmissionColor("Emission Color", Color) = (0,0,0,1)
+        _Emission("Emission Scale", Float) = 1
+        [Header(Audio Section)][IntRange]_Band("Band", Range( 0 , 3)) = 0
+        _Delay("Delay", Range( 0 , 1)) = 0
+        [Header(Pulse Across UVs)]_Pulse("Pulse", Range( 0 , 1)) = 0
+        _AudioHueShift("Audio Hue Shift", Float) = 0
+        _PulseRotation("Pulse Rotation", Range( 0 , 360)) = 0
+        [HideInInspector] _texcoord( "", 2D ) = "white" {}
+    }
 
-		//_TransmissionShadow( "Transmission Shadow", Range( 0, 1 ) ) = 0.5
-		//_TransStrength( "Trans Strength", Range( 0, 50 ) ) = 1
-		//_TransNormal( "Trans Normal Distortion", Range( 0, 1 ) ) = 0.5
-		//_TransScattering( "Trans Scattering", Range( 1, 50 ) ) = 2
-		//_TransDirect( "Trans Direct", Range( 0, 1 ) ) = 0.9
-		//_TransAmbient( "Trans Ambient", Range( 0, 1 ) ) = 0.1
-		//_TransShadow( "Trans Shadow", Range( 0, 1 ) ) = 0.5
-		//_TessPhongStrength( "Tess Phong Strength", Range( 0, 1 ) ) = 0.5
-		//_TessValue( "Tess Max Tessellation", Range( 1, 32 ) ) = 16
-		//_TessMin( "Tess Min Distance", Float ) = 10
-		//_TessMax( "Tess Max Distance", Float ) = 25
-		//_TessEdgeLength ( "Tess Edge length", Range( 2, 50 ) ) = 16
-		//_TessMaxDisp( "Tess Max Displacement", Float ) = 25
-		//[ToggleOff] _SpecularHighlights("Specular Highlights", Float) = 1.0
-		//[ToggleOff] _GlossyReflections("Reflections", Float) = 1.0
-	}
-	
-	SubShader
-	{
-		
-		Tags { "RenderType"="Transparent" "Queue"="Transparent" "DisableBatching"="False" }
-	LOD 0
+    SubShader
+    {
 
-		Cull Back
-		AlphaToMask Off
-		ZWrite Off
-		ZTest LEqual
-		ColorMask RGBA
-		
-		Blend Off
-		
+        Tags
+        {
+            "RenderType"="Transparent" "Queue"="Transparent" "DisableBatching"="False"
+        }
+        LOD 0
 
-		CGINCLUDE
-		#pragma target 3.0
+        Cull Back
+        AlphaToMask Off
+        ZWrite Off
+        ZTest LEqual
+        ColorMask RGBA
 
-		float4 FixedTess( float tessValue )
-		{
-			return tessValue;
-		}
-		
-		float CalcDistanceTessFactor (float4 vertex, float minDist, float maxDist, float tess, float4x4 o2w, float3 cameraPos )
-		{
-			float3 wpos = mul(o2w,vertex).xyz;
-			float dist = distance (wpos, cameraPos);
-			float f = clamp(1.0 - (dist - minDist) / (maxDist - minDist), 0.01, 1.0) * tess;
-			return f;
-		}
+        Blend Off
 
-		float4 CalcTriEdgeTessFactors (float3 triVertexFactors)
-		{
-			float4 tess;
-			tess.x = 0.5 * (triVertexFactors.y + triVertexFactors.z);
-			tess.y = 0.5 * (triVertexFactors.x + triVertexFactors.z);
-			tess.z = 0.5 * (triVertexFactors.x + triVertexFactors.y);
-			tess.w = (triVertexFactors.x + triVertexFactors.y + triVertexFactors.z) / 3.0f;
-			return tess;
-		}
 
-		float CalcEdgeTessFactor (float3 wpos0, float3 wpos1, float edgeLen, float3 cameraPos, float4 scParams )
-		{
-			float dist = distance (0.5 * (wpos0+wpos1), cameraPos);
-			float len = distance(wpos0, wpos1);
-			float f = max(len * scParams.y / (edgeLen * dist), 1.0);
-			return f;
-		}
+        CGINCLUDE
+        #pragma target 3.0
 
-		float DistanceFromPlane (float3 pos, float4 plane)
-		{
-			float d = dot (float4(pos,1.0f), plane);
-			return d;
-		}
+        float4 FixedTess(float tessValue)
+        {
+            return tessValue;
+        }
 
-		bool WorldViewFrustumCull (float3 wpos0, float3 wpos1, float3 wpos2, float cullEps, float4 planes[6] )
-		{
-			float4 planeTest;
-			planeTest.x = (( DistanceFromPlane(wpos0, planes[0]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos1, planes[0]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos2, planes[0]) > -cullEps) ? 1.0f : 0.0f );
-			planeTest.y = (( DistanceFromPlane(wpos0, planes[1]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos1, planes[1]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos2, planes[1]) > -cullEps) ? 1.0f : 0.0f );
-			planeTest.z = (( DistanceFromPlane(wpos0, planes[2]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos1, planes[2]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos2, planes[2]) > -cullEps) ? 1.0f : 0.0f );
-			planeTest.w = (( DistanceFromPlane(wpos0, planes[3]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos1, planes[3]) > -cullEps) ? 1.0f : 0.0f ) +
-						  (( DistanceFromPlane(wpos2, planes[3]) > -cullEps) ? 1.0f : 0.0f );
-			return !all (planeTest);
-		}
+        float CalcDistanceTessFactor(float4 vertex, float minDist, float maxDist, float tess, float4x4 o2w,
+                                                                          float3 cameraPos)
+        {
+            float3 wpos = mul(o2w, vertex).xyz;
+            float dist = distance(wpos, cameraPos);
+            float f = clamp(1.0 - (dist - minDist) / (maxDist - minDist), 0.01, 1.0) * tess;
+            return f;
+        }
 
-		float4 DistanceBasedTess( float4 v0, float4 v1, float4 v2, float tess, float minDist, float maxDist, float4x4 o2w, float3 cameraPos )
-		{
-			float3 f;
-			f.x = CalcDistanceTessFactor (v0,minDist,maxDist,tess,o2w,cameraPos);
-			f.y = CalcDistanceTessFactor (v1,minDist,maxDist,tess,o2w,cameraPos);
-			f.z = CalcDistanceTessFactor (v2,minDist,maxDist,tess,o2w,cameraPos);
+        float4 CalcTriEdgeTessFactors(float3 triVertexFactors)
+        {
+            float4 tess;
+            tess.x = 0.5 * (triVertexFactors.y + triVertexFactors.z);
+            tess.y = 0.5 * (triVertexFactors.x + triVertexFactors.z);
+            tess.z = 0.5 * (triVertexFactors.x + triVertexFactors.y);
+            tess.w = (triVertexFactors.x + triVertexFactors.y + triVertexFactors.z) / 3.0f;
+            return tess;
+        }
 
-			return CalcTriEdgeTessFactors (f);
-		}
+        float CalcEdgeTessFactor(float3 wpos0, float3 wpos1, float edgeLen, float3 cameraPos, float4 scParams)
+        {
+            float dist = distance(0.5 * (wpos0 + wpos1), cameraPos);
+            float len = distance(wpos0, wpos1);
+            float f = max(len * scParams.y / (edgeLen * dist), 1.0);
+            return f;
+        }
 
-		float4 EdgeLengthBasedTess( float4 v0, float4 v1, float4 v2, float edgeLength, float4x4 o2w, float3 cameraPos, float4 scParams )
-		{
-			float3 pos0 = mul(o2w,v0).xyz;
-			float3 pos1 = mul(o2w,v1).xyz;
-			float3 pos2 = mul(o2w,v2).xyz;
-			float4 tess;
-			tess.x = CalcEdgeTessFactor (pos1, pos2, edgeLength, cameraPos, scParams);
-			tess.y = CalcEdgeTessFactor (pos2, pos0, edgeLength, cameraPos, scParams);
-			tess.z = CalcEdgeTessFactor (pos0, pos1, edgeLength, cameraPos, scParams);
-			tess.w = (tess.x + tess.y + tess.z) / 3.0f;
-			return tess;
-		}
+        float DistanceFromPlane(float3 pos, float4 plane)
+        {
+            float d = dot(float4(pos, 1.0f), plane);
+            return d;
+        }
 
-		float4 EdgeLengthBasedTessCull( float4 v0, float4 v1, float4 v2, float edgeLength, float maxDisplacement, float4x4 o2w, float3 cameraPos, float4 scParams, float4 planes[6] )
-		{
-			float3 pos0 = mul(o2w,v0).xyz;
-			float3 pos1 = mul(o2w,v1).xyz;
-			float3 pos2 = mul(o2w,v2).xyz;
-			float4 tess;
+        bool WorldViewFrustumCull(float3 wpos0, float3 wpos1, float3 wpos2, float cullEps, float4 planes[6])
+        {
+            float4 planeTest;
+            planeTest.x = ((DistanceFromPlane(wpos0, planes[0]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos1, planes[0]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos2, planes[0]) > -cullEps) ? 1.0f : 0.0f);
+            planeTest.y = ((DistanceFromPlane(wpos0, planes[1]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos1, planes[1]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos2, planes[1]) > -cullEps) ? 1.0f : 0.0f);
+            planeTest.z = ((DistanceFromPlane(wpos0, planes[2]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos1, planes[2]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos2, planes[2]) > -cullEps) ? 1.0f : 0.0f);
+            planeTest.w = ((DistanceFromPlane(wpos0, planes[3]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos1, planes[3]) > -cullEps) ? 1.0f : 0.0f) +
+                ((DistanceFromPlane(wpos2, planes[3]) > -cullEps) ? 1.0f : 0.0f);
+            return !all(planeTest);
+        }
 
-			if (WorldViewFrustumCull(pos0, pos1, pos2, maxDisplacement, planes))
-			{
-				tess = 0.0f;
-			}
-			else
-			{
-				tess.x = CalcEdgeTessFactor (pos1, pos2, edgeLength, cameraPos, scParams);
-				tess.y = CalcEdgeTessFactor (pos2, pos0, edgeLength, cameraPos, scParams);
-				tess.z = CalcEdgeTessFactor (pos0, pos1, edgeLength, cameraPos, scParams);
-				tess.w = (tess.x + tess.y + tess.z) / 3.0f;
-			}
-			return tess;
-		}
-		ENDCG
+        float4 DistanceBasedTess(float4 v0, float4 v1, float4 v2, float tess, float minDist, float maxDist,
+                                                float4x4 o2w, float3 cameraPos)
+        {
+            float3 f;
+            f.x = CalcDistanceTessFactor(v0, minDist, maxDist, tess, o2w, cameraPos);
+            f.y = CalcDistanceTessFactor(v1, minDist, maxDist, tess, o2w, cameraPos);
+            f.z = CalcDistanceTessFactor(v2, minDist, maxDist, tess, o2w, cameraPos);
 
-		
-		Pass
-		{
-			
-			Name "ForwardBase"
-			Tags { "LightMode"="ForwardBase" }
-			
-			Blend SrcAlpha OneMinusSrcAlpha
+            return CalcTriEdgeTessFactors(f);
+        }
 
-			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
-			#define _ALPHATEST_ON 1
+        float4 EdgeLengthBasedTess(float4 v0, float4 v1, float4 v2, float edgeLength, float4x4 o2w, float3 cameraPos,
+                               float4 scParams)
+        {
+            float3 pos0 = mul(o2w, v0).xyz;
+            float3 pos1 = mul(o2w, v1).xyz;
+            float3 pos2 = mul(o2w, v2).xyz;
+            float4 tess;
+            tess.x = CalcEdgeTessFactor(pos1, pos2, edgeLength, cameraPos, scParams);
+            tess.y = CalcEdgeTessFactor(pos2, pos0, edgeLength, cameraPos, scParams);
+            tess.z = CalcEdgeTessFactor(pos0, pos1, edgeLength, cameraPos, scParams);
+            tess.w = (tess.x + tess.y + tess.z) / 3.0f;
+            return tess;
+        }
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma multi_compile_fwdbase
-			#ifndef UNITY_PASS_FORWARDBASE
-				#define UNITY_PASS_FORWARDBASE
-			#endif
-			#include "HLSLSupport.cginc"
-			#ifndef UNITY_INSTANCED_LOD_FADE
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#ifndef UNITY_INSTANCED_SH
-				#define UNITY_INSTANCED_SH
-			#endif
-			#ifndef UNITY_INSTANCED_LIGHTMAPSTS
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "AutoLight.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+        float4 EdgeLengthBasedTessCull(float4 v0, float4 v1, float4 v2, float edgeLength, float maxDisplacement,
+                    float4x4 o2w, float3 cameraPos, float4 scParams, float4 planes[6])
+        {
+            float3 pos0 = mul(o2w, v0).xyz;
+            float3 pos1 = mul(o2w, v1).xyz;
+            float3 pos2 = mul(o2w, v2).xyz;
+            float4 tess;
 
-			#pragma multi_compile_instancing
+            if (WorldViewFrustumCull(pos0, pos1, pos2, maxDisplacement, planes))
+            {
+                tess = 0.0f;
+            }
+            else
+            {
+                tess.x = CalcEdgeTessFactor(pos1, pos2, edgeLength, cameraPos, scParams);
+                tess.y = CalcEdgeTessFactor(pos2, pos0, edgeLength, cameraPos, scParams);
+                tess.z = CalcEdgeTessFactor(pos0, pos1, edgeLength, cameraPos, scParams);
+                tess.w = (tess.x + tess.y + tess.z) / 3.0f;
+            }
+            return tess;
+        }
+        ENDCG
 
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
-			
-			struct v2f {
-				#if UNITY_VERSION >= 201810
+
+        Pass
+        {
+            Blend SrcAlpha OneMinusSrcAlpha
+
+            CGPROGRAM
+            #define _ALPHABLEND_ON 1
+            #define UNITY_STANDARD_USE_DITHER_MASK 1
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
+            #define _ALPHATEST_ON 1
+
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_fwdbase
+            #ifndef UNITY_PASS_FORWARDBASE
+            #define UNITY_PASS_FORWARDBASE
+            #endif
+            #include "HLSLSupport.cginc"
+            #ifndef UNITY_INSTANCED_LOD_FADE
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #ifndef UNITY_INSTANCED_SH
+            #define UNITY_INSTANCED_SH
+            #endif
+            #ifndef UNITY_INSTANCED_LIGHTMAPSTS
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "AutoLight.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            #pragma multi_compile_instancing
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+                float4 ase_texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                #if UNITY_VERSION >= 201810
 					UNITY_POSITION(pos);
-				#else
-					float4 pos : SV_POSITION;
-				#endif
-				#if defined(LIGHTMAP_ON) || (!defined(LIGHTMAP_ON) && SHADER_TARGET >= 30)
+                #else
+                float4 pos : SV_POSITION;
+                #endif
+                #if defined(LIGHTMAP_ON) || (!defined(LIGHTMAP_ON) && SHADER_TARGET >= 30)
 					float4 lmap : TEXCOORD0;
-				#endif
-				#if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH
+                #endif
+                #if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH
 					half3 sh : TEXCOORD1;
-				#endif
-				#if defined(UNITY_HALF_PRECISION_FRAGMENT_SHADER_REGISTERS) && UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #endif
+                #if defined(UNITY_HALF_PRECISION_FRAGMENT_SHADER_REGISTERS) && UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
 					UNITY_LIGHTING_COORDS(2,3)
-				#elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					#if UNITY_VERSION >= 201710
+                #elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201710
 						UNITY_SHADOW_COORDS(2)
-					#else
-						SHADOW_COORDS(2)
-					#endif
-				#endif
-				#ifdef ASE_FOG
-					UNITY_FOG_COORDS(4)
-				#endif
-				float4 tSpace0 : TEXCOORD5;
-				float4 tSpace1 : TEXCOORD6;
-				float4 tSpace2 : TEXCOORD7;
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #else
+                SHADOW_COORDS(2)
+                #endif
+                #endif
+                #ifdef ASE_FOG
+                UNITY_FOG_COORDS(4)
+                #endif
+                float4 tSpace0 : TEXCOORD5;
+                float4 tSpace1 : TEXCOORD6;
+                float4 tSpace2 : TEXCOORD7;
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 				float4 screenPos : TEXCOORD8;
-				#endif
-				float4 ase_texcoord9 : TEXCOORD9;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+                #endif
+                float4 ase_texcoord9 : TEXCOORD9;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
 
-			#ifdef _TRANSMISSION_ASE
+            #ifdef _TRANSMISSION_ASE
 				float _TransmissionShadow;
-			#endif
-			#ifdef _TRANSLUCENCY_ASE
+            #endif
+            #ifdef _TRANSLUCENCY_ASE
 				float _TransStrength;
 				float _TransNormal;
 				float _TransScattering;
 				float _TransDirect;
 				float _TransAmbient;
 				float _TransShadow;
-			#endif
-			#ifdef TESSELLATION_ON
+            #endif
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			uniform sampler2D _MainTex;
-			uniform float4 _Color;
-			uniform sampler2D _BumpMap;
-			uniform float _BumpScale;
-			uniform sampler2D _EmissionMap;
-			uniform float _Metallic;
-			uniform float _Smoothness;
-			uniform float _Cutoff;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
-				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+            #endif
+            uniform sampler2D _MainTex;
+            uniform float4 _Color;
+            uniform sampler2D _BumpMap;
+            uniform float _BumpScale;
+            uniform sampler2D _EmissionMap;
+            uniform float _Metallic;
+            uniform float _Smoothness;
+            uniform float _Cutoff;
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
+                #define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
+                #define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
+                #define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
+                #define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Band)
+                #define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
+                #define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
+                #define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
+                #define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
+                #define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
-	
-			float3 HSVToRGB( float3 c )
-			{
-				float4 K = float4( 1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0 );
-				float3 p = abs( frac( c.xxx + K.xyz ) * 6.0 - K.www );
-				return c.z * lerp( K.xxx, saturate( p - K.xxx ), c.y );
-			}
-			
-			float3 RGBToHSV(float3 c)
-			{
-				float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-				float4 p = lerp( float4( c.bg, K.wz ), float4( c.gb, K.xy ), step( c.b, c.g ) );
-				float4 q = lerp( float4( p.xyw, c.r ), float4( c.r, p.yzx ), step( p.x, c.r ) );
-				float d = q.x - min( q.w, q.y );
-				float e = 1.0e-10;
-				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-			}
-			inline float AudioLinkLerp3_g8( int Band, float Delay )
-			{
-				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
-			}
-			
 
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+            float3 HSVToRGB(float3 c)
+            {
+                float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                float3 p = abs(frac(c.xxx + K.xyz) * 6.0 - K.www);
+                return c.z * lerp(K.xxx, saturate(p - K.xxx), c.y);
+            }
 
-				o.ase_texcoord9.xy = v.ase_texcoord.xy;
-				
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord9.zw = 0;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            float3 RGBToHSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            inline float AudioLinkLerp3_g8(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                    UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.ase_texcoord9.xy = v.ase_texcoord.xy;
+
+                //setting value to unused interpolator channels and avoid initialization warnings
+                o.ase_texcoord9.zw = 0;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				o.pos = UnityObjectToClipPos(v.vertex);
-				float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
-				fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
-				fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
-				fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
-				fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
-				o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
-				o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
-				o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
+                o.pos = UnityObjectToClipPos(v.vertex);
+                float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
+                fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
+                fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
+                fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
+                fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
+                o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
+                o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
+                o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
 
-				#ifdef DYNAMICLIGHTMAP_ON
+                #ifdef DYNAMICLIGHTMAP_ON
 				o.lmap.zw = v.texcoord2.xy * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
-				#endif
-				#ifdef LIGHTMAP_ON
+                #endif
+                #ifdef LIGHTMAP_ON
 				o.lmap.xy = v.texcoord1.xy * unity_LightmapST.xy + unity_LightmapST.zw;
-				#endif
+                #endif
 
-				#ifndef LIGHTMAP_ON
-					#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #ifndef LIGHTMAP_ON
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 						o.sh = 0;
-						#ifdef VERTEXLIGHT_ON
+                #ifdef VERTEXLIGHT_ON
 						o.sh += Shade4PointLights (
 							unity_4LightPosX0, unity_4LightPosY0, unity_4LightPosZ0,
 							unity_LightColor[0].rgb, unity_LightColor[1].rgb, unity_LightColor[2].rgb, unity_LightColor[3].rgb,
 							unity_4LightAtten0, worldPos, worldNormal);
-						#endif
+                #endif
 						o.sh = ShadeSHPerVertex (worldNormal, o.sh);
-					#endif
-				#endif
+                #endif
+                #endif
 
-				#if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
 					UNITY_TRANSFER_LIGHTING(o, v.texcoord1.xy);
-				#elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					#if UNITY_VERSION >= 201710
+                #elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201710
 						UNITY_TRANSFER_SHADOW(o, v.texcoord1.xy);
-					#else
-						TRANSFER_SHADOW(o);
-					#endif
-				#endif
+                #else
+                TRANSFER_SHADOW(o);
+                #endif
+                #endif
 
-				#ifdef ASE_FOG
-					UNITY_TRANSFER_FOG(o,o.pos);
-				#endif
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #ifdef ASE_FOG
+                UNITY_TRANSFER_FOG(o, o.pos);
+                #endif
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 					o.screenPos = ComputeScreenPos(o.pos);
-				#endif
-				return o;
-			}
+                #endif
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -432,15 +423,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -465,202 +456,210 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
 				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
-				#if defined(ASE_PHONG_TESSELLATION)
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
-			
-			fixed4 frag (v2f IN 
-				#ifdef _DEPTHOFFSET_ON
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
+
+            fixed4 frag(v2f IN
+                #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-				) : SV_Target 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
+                #endif
+            ) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
 
-				#ifdef LOD_FADE_CROSSFADE
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
-				float3 WorldTangent = float3(IN.tSpace0.x,IN.tSpace1.x,IN.tSpace2.x);
-				float3 WorldBiTangent = float3(IN.tSpace0.y,IN.tSpace1.y,IN.tSpace2.y);
-				float3 WorldNormal = float3(IN.tSpace0.z,IN.tSpace1.z,IN.tSpace2.z);
-				float3 worldPos = float3(IN.tSpace0.w,IN.tSpace1.w,IN.tSpace2.w);
-				float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
-				#if defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					UNITY_LIGHT_ATTENUATION(atten, IN, worldPos)
-				#else
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
+                float3 WorldTangent = float3(IN.tSpace0.x, IN.tSpace1.x, IN.tSpace2.x);
+                float3 WorldBiTangent = float3(IN.tSpace0.y, IN.tSpace1.y, IN.tSpace2.y);
+                float3 WorldNormal = float3(IN.tSpace0.z, IN.tSpace1.z, IN.tSpace2.z);
+                float3 worldPos = float3(IN.tSpace0.w, IN.tSpace1.w, IN.tSpace2.w);
+                float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
+                #if defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                UNITY_LIGHT_ATTENUATION(atten, IN, worldPos)
+                #else
 					half atten = 1;
-				#endif
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #endif
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 				float4 ScreenPos = IN.screenPos;
-				#endif
+                #endif
 
-				float2 texCoord6 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2DNode4 * _Color ).rgb );
-				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
-				float hueShift33 = _AudioHueShift_Instance;
-				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g8 = (int)_Band_Instance;
-				float2 texCoord50 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g10 = texCoord50;
-				float temp_output_5_0_g10 = ( break6_g10.x - 0.5 );
-				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g10 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g10 = cos( temp_output_2_0_g10 );
-				float temp_output_8_0_g10 = sin( temp_output_2_0_g10 );
-				float temp_output_20_0_g10 = ( 1.0 / ( abs( temp_output_3_0_g10 ) + abs( temp_output_8_0_g10 ) ) );
-				float temp_output_7_0_g10 = ( break6_g10.y - 0.5 );
-				float2 appendResult16_g10 = (float2(( ( ( temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) + ( temp_output_7_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) - ( temp_output_5_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 )));
-				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
-				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g8 = ( ( (_Delay_Instance + (( appendResult16_g10.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8( Band3_g8 , Delay3_g8 );
-				float temp_output_96_0 = localAudioLinkLerp3_g8;
-				float amplitude36 = temp_output_96_0;
-				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
-				
-				float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
-				float2 uv_BumpMap = IN.ase_texcoord9.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
-				
-				float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
-				float2 uv_EmissionMap = IN.ase_texcoord9.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
-				float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
-				float3 hsvTorgb40 = RGBToHSV( ( tex2D( _EmissionMap, uv_EmissionMap ) * _EmissionColor_Instance * temp_output_96_0 ).rgb );
-				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
-				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
-				
-				float alpha98 = tex2DNode4.a;
-				
-				o.Albedo = hsvTorgb39;
-				o.Normal = ( UnpackNormal( tex2D( _BumpMap, uv_BumpMap ) ) * _BumpScale );
-				o.Emission = ( hsvTorgb45 * _Emission_Instance );
-				#if defined(_SPECULAR_SETUP)
+                float2 texCoord6 = IN.ase_texcoord9.xy * float2(1, 1) + float2(0, 0);
+                float4 tex2DNode4 = tex2D(_MainTex, texCoord6);
+                float3 hsvTorgb32 = RGBToHSV((tex2DNode4 * _Color).rgb);
+                float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
+                float hueShift33 = _AudioHueShift_Instance;
+                float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
+                int Band3_g8 = (int)_Band_Instance;
+                float2 texCoord50 = IN.ase_texcoord9.xy * float2(1, 1) + float2(0, 0);
+                float2 break6_g10 = texCoord50;
+                float temp_output_5_0_g10 = (break6_g10.x - 0.5);
+                float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
+                float temp_output_2_0_g10 = radians(_PulseRotation_Instance);
+                float temp_output_3_0_g10 = cos(temp_output_2_0_g10);
+                float temp_output_8_0_g10 = sin(temp_output_2_0_g10);
+                float temp_output_20_0_g10 = (1.0 / (abs(temp_output_3_0_g10) + abs(temp_output_8_0_g10)));
+                float temp_output_7_0_g10 = (break6_g10.y - 0.5);
+                float2 appendResult16_g10 = (float2(
+                    (((temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10) + (temp_output_7_0_g10 *
+                        temp_output_8_0_g10 * temp_output_20_0_g10)) + 0.5),
+                    (((temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10) - (temp_output_5_0_g10 *
+                        temp_output_8_0_g10 * temp_output_20_0_g10)) + 0.5)));
+                float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
+                float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
+                float Delay3_g8 = (((_Delay_Instance + ((appendResult16_g10.x * _Pulse_Instance) - 0.0) * (1.0 -
+                    _Delay_Instance) / (1.0 - 0.0)) % 1.0) * 128.0);
+                float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8(Band3_g8, Delay3_g8);
+                float temp_output_96_0 = localAudioLinkLerp3_g8;
+                float amplitude36 = temp_output_96_0;
+                float3 hsvTorgb39 = HSVToRGB(float3((hsvTorgb32.x + (hueShift33 * amplitude36)), hsvTorgb32.y,
+                                   hsvTorgb32.z));
+
+                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
+                float2 uv_BumpMap = IN.ase_texcoord9.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
+
+                float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
+                float2 uv_EmissionMap = IN.ase_texcoord9.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
+                float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
+                float3 hsvTorgb40 = RGBToHSV(
+                    (tex2D(_EmissionMap, uv_EmissionMap) * _EmissionColor_Instance * temp_output_96_0).rgb);
+                float3 hsvTorgb45 = HSVToRGB(float3((hsvTorgb40.x + (hueShift33 * amplitude36)), hsvTorgb40.y,
+                                       hsvTorgb40.z));
+                float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
+
+                float alpha98 = tex2DNode4.a;
+
+                o.Albedo = hsvTorgb39;
+                o.Normal = (UnpackNormal(tex2D(_BumpMap, uv_BumpMap)) * _BumpScale);
+                o.Emission = (hsvTorgb45 * _Emission_Instance);
+                #if defined(_SPECULAR_SETUP)
 					o.Specular = fixed3( 0, 0, 0 );
-				#else
-					o.Metallic = _Metallic;
-				#endif
-				o.Smoothness = _Smoothness;
-				o.Occlusion = 1;
-				o.Alpha = alpha98;
-				float AlphaClipThreshold = _Cutoff;
-				float AlphaClipThresholdShadow = 0.5;
-				float3 BakedGI = 0;
-				float3 RefractionColor = 1;
-				float RefractionIndex = 1;
-				float3 Transmission = 1;
-				float3 Translucency = 1;				
+                #else
+                o.Metallic = _Metallic;
+                #endif
+                o.Smoothness = _Smoothness;
+                o.Occlusion = 1;
+                o.Alpha = alpha98;
+                float AlphaClipThreshold = _Cutoff;
+                float AlphaClipThresholdShadow = 0.5;
+                float3 BakedGI = 0;
+                float3 RefractionColor = 1;
+                float RefractionIndex = 1;
+                float3 Transmission = 1;
+                float3 Translucency = 1;
 
-				#ifdef _ALPHATEST_ON
-					clip( o.Alpha - AlphaClipThreshold );
-				#endif
+                #ifdef _ALPHATEST_ON
+                clip(o.Alpha - AlphaClipThreshold);
+                #endif
 
-				#ifdef _DEPTHOFFSET_ON
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				#ifndef USING_DIRECTIONAL_LIGHT
-					fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
-				#else
+                #ifndef USING_DIRECTIONAL_LIGHT
+                fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
+                #else
 					fixed3 lightDir = _WorldSpaceLightPos0.xyz;
-				#endif
+                #endif
 
-				fixed4 c = 0;
-				float3 worldN;
-				worldN.x = dot(IN.tSpace0.xyz, o.Normal);
-				worldN.y = dot(IN.tSpace1.xyz, o.Normal);
-				worldN.z = dot(IN.tSpace2.xyz, o.Normal);
-				worldN = normalize(worldN);
-				o.Normal = worldN;
+                fixed4 c = 0;
+                float3 worldN;
+                worldN.x = dot(IN.tSpace0.xyz, o.Normal);
+                worldN.y = dot(IN.tSpace1.xyz, o.Normal);
+                worldN.z = dot(IN.tSpace2.xyz, o.Normal);
+                worldN = normalize(worldN);
+                o.Normal = worldN;
 
-				UnityGI gi;
-				UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
-				gi.indirect.diffuse = 0;
-				gi.indirect.specular = 0;
-				gi.light.color = _LightColor0.rgb;
-				gi.light.dir = lightDir;
+                UnityGI gi;
+                    UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
+                gi.indirect.diffuse = 0;
+                gi.indirect.specular = 0;
+                gi.light.color = _LightColor0.rgb;
+                gi.light.dir = lightDir;
 
-				UnityGIInput giInput;
-				UNITY_INITIALIZE_OUTPUT(UnityGIInput, giInput);
-				giInput.light = gi.light;
-				giInput.worldPos = worldPos;
-				giInput.worldViewDir = worldViewDir;
-				giInput.atten = atten;
-				#if defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)
+                UnityGIInput giInput;
+                UNITY_INITIALIZE_OUTPUT(UnityGIInput, giInput);
+                giInput.light = gi.light;
+                giInput.worldPos = worldPos;
+                giInput.worldViewDir = worldViewDir;
+                giInput.atten = atten;
+                #if defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)
 					giInput.lightmapUV = IN.lmap;
-				#else
-					giInput.lightmapUV = 0.0;
-				#endif
-				#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #else
+                giInput.lightmapUV = 0.0;
+                #endif
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 					giInput.ambient = IN.sh;
-				#else
-					giInput.ambient.rgb = 0.0;
-				#endif
-				giInput.probeHDR[0] = unity_SpecCube0_HDR;
-				giInput.probeHDR[1] = unity_SpecCube1_HDR;
-				#if defined(UNITY_SPECCUBE_BLENDING) || defined(UNITY_SPECCUBE_BOX_PROJECTION)
+                #else
+                giInput.ambient.rgb = 0.0;
+                #endif
+                giInput.probeHDR[0] = unity_SpecCube0_HDR;
+                giInput.probeHDR[1] = unity_SpecCube1_HDR;
+                #if defined(UNITY_SPECCUBE_BLENDING) || defined(UNITY_SPECCUBE_BOX_PROJECTION)
 					giInput.boxMin[0] = unity_SpecCube0_BoxMin;
-				#endif
-				#ifdef UNITY_SPECCUBE_BOX_PROJECTION
+                #endif
+                #ifdef UNITY_SPECCUBE_BOX_PROJECTION
 					giInput.boxMax[0] = unity_SpecCube0_BoxMax;
 					giInput.probePosition[0] = unity_SpecCube0_ProbePosition;
 					giInput.boxMax[1] = unity_SpecCube1_BoxMax;
 					giInput.boxMin[1] = unity_SpecCube1_BoxMin;
 					giInput.probePosition[1] = unity_SpecCube1_ProbePosition;
-				#endif
-				
-				#if defined(_SPECULAR_SETUP)
+                #endif
+
+                #if defined(_SPECULAR_SETUP)
 					LightingStandardSpecular_GI(o, giInput, gi);
-				#else
-					LightingStandard_GI( o, giInput, gi );
-				#endif
+                #else
+                LightingStandard_GI(o, giInput, gi);
+                #endif
 
-				#ifdef ASE_BAKEDGI
+                #ifdef ASE_BAKEDGI
 					gi.indirect.diffuse = BakedGI;
-				#endif
+                #endif
 
-				#if UNITY_SHOULD_SAMPLE_SH && !defined(LIGHTMAP_ON) && defined(ASE_NO_AMBIENT)
+                #if UNITY_SHOULD_SAMPLE_SH && !defined(LIGHTMAP_ON) && defined(ASE_NO_AMBIENT)
 					gi.indirect.diffuse = 0;
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					c += LightingStandardSpecular (o, worldViewDir, gi);
-				#else
-					c += LightingStandard( o, worldViewDir, gi );
-				#endif
-				
-				#ifdef _TRANSMISSION_ASE
+                #else
+                c += LightingStandard(o, worldViewDir, gi);
+                #endif
+
+                #ifdef _TRANSMISSION_ASE
 				{
 					float shadow = _TransmissionShadow;
-					#ifdef DIRECTIONAL
+                #ifdef DIRECTIONAL
 						float3 lightAtten = lerp( _LightColor0.rgb, gi.light.color, shadow );
-					#else
+                #else
 						float3 lightAtten = gi.light.color;
-					#endif
+                #endif
 					half3 transmission = max(0 , -dot(o.Normal, gi.light.dir)) * lightAtten * Transmission;
 					c.rgb += o.Albedo * transmission;
 				}
-				#endif
+                #endif
 
-				#ifdef _TRANSLUCENCY_ASE
+                #ifdef _TRANSLUCENCY_ASE
 				{
 					float shadow = _TransShadow;
 					float normal = _TransNormal;
@@ -669,247 +668,255 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 					float ambient = _TransAmbient;
 					float strength = _TransStrength;
 
-					#ifdef DIRECTIONAL
+                #ifdef DIRECTIONAL
 						float3 lightAtten = lerp( _LightColor0.rgb, gi.light.color, shadow );
-					#else
+                #else
 						float3 lightAtten = gi.light.color;
-					#endif
+                #endif
 					half3 lightDir = gi.light.dir + o.Normal * normal;
 					half transVdotL = pow( saturate( dot( worldViewDir, -lightDir ) ), scattering );
 					half3 translucency = lightAtten * (transVdotL * direct + gi.indirect.diffuse * ambient) * Translucency;
 					c.rgb += o.Albedo * translucency * strength;
 				}
-				#endif
+                #endif
 
-				//#ifdef _REFRACTION_ASE
-				//	float4 projScreenPos = ScreenPos / ScreenPos.w;
-				//	float3 refractionOffset = ( RefractionIndex - 1.0 ) * mul( UNITY_MATRIX_V, WorldNormal ).xyz * ( 1.0 - dot( WorldNormal, WorldViewDirection ) );
-				//	projScreenPos.xy += refractionOffset.xy;
-				//	float3 refraction = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _GrabTexture, projScreenPos ) * RefractionColor;
-				//	color.rgb = lerp( refraction, color.rgb, color.a );
-				//	color.a = 1;
-				//#endif
+                //#ifdef _REFRACTION_ASE
+                //	float4 projScreenPos = ScreenPos / ScreenPos.w;
+                //	float3 refractionOffset = ( RefractionIndex - 1.0 ) * mul( UNITY_MATRIX_V, WorldNormal ).xyz * ( 1.0 - dot( WorldNormal, WorldViewDirection ) );
+                //	projScreenPos.xy += refractionOffset.xy;
+                //	float3 refraction = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _GrabTexture, projScreenPos ) * RefractionColor;
+                //	color.rgb = lerp( refraction, color.rgb, color.a );
+                //	color.a = 1;
+                //#endif
 
-				c.rgb += o.Emission;
+                c.rgb += o.Emission;
 
-				#ifdef ASE_FOG
-					UNITY_APPLY_FOG(IN.fogCoord, c);
-				#endif
-				return c;
-			}
-			ENDCG
-		}
+                #ifdef ASE_FOG
+                UNITY_APPLY_FOG(IN.fogCoord, c);
+                #endif
+                return c;
+            }
+            ENDCG
+        }
 
-		
-		Pass
-		{
-			
-			Name "ForwardAdd"
-			Tags { "LightMode"="ForwardAdd" }
-			ZWrite Off
-			Blend SrcAlpha One
 
-			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
-			#define _ALPHATEST_ON 1
+        Pass
+        {
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma skip_variants INSTANCING_ON
-			#pragma multi_compile_fwdadd_fullshadows
-			#ifndef UNITY_PASS_FORWARDADD
-				#define UNITY_PASS_FORWARDADD
-			#endif
-			#include "HLSLSupport.cginc"
-			#if !defined( UNITY_INSTANCED_LOD_FADE )
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#if !defined( UNITY_INSTANCED_SH )
-				#define UNITY_INSTANCED_SH
-			#endif
-			#if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "AutoLight.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            Name "ForwardAdd"
+            Tags
+            {
+                "LightMode"="ForwardAdd"
+            }
+            ZWrite Off
+            Blend SrcAlpha One
 
-			#pragma multi_compile_instancing
+            CGPROGRAM
+            #define _ALPHABLEND_ON 1
+            #define UNITY_STANDARD_USE_DITHER_MASK 1
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
+            #define _ALPHATEST_ON 1
 
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
-			struct v2f {
-				#if UNITY_VERSION >= 201810
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma skip_variants INSTANCING_ON
+            #pragma multi_compile_fwdadd_fullshadows
+            #ifndef UNITY_PASS_FORWARDADD
+            #define UNITY_PASS_FORWARDADD
+            #endif
+            #include "HLSLSupport.cginc"
+            #if !defined( UNITY_INSTANCED_LOD_FADE )
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #if !defined( UNITY_INSTANCED_SH )
+            #define UNITY_INSTANCED_SH
+            #endif
+            #if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "AutoLight.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            #pragma multi_compile_instancing
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+                float4 ase_texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                #if UNITY_VERSION >= 201810
 					UNITY_POSITION(pos);
-				#else
-					float4 pos : SV_POSITION;
-				#endif
-				#if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #else
+                float4 pos : SV_POSITION;
+                #endif
+                #if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
 					UNITY_LIGHTING_COORDS(1,2)
-				#elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					#if UNITY_VERSION >= 201710
+                #elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201710
 						UNITY_SHADOW_COORDS(1)
-					#else
-						SHADOW_COORDS(1)
-					#endif
-				#endif
-				#ifdef ASE_FOG
-					UNITY_FOG_COORDS(3)
-				#endif
-				float4 tSpace0 : TEXCOORD5;
-				float4 tSpace1 : TEXCOORD6;
-				float4 tSpace2 : TEXCOORD7;
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #else
+                SHADOW_COORDS(1)
+                #endif
+                #endif
+                #ifdef ASE_FOG
+                UNITY_FOG_COORDS(3)
+                #endif
+                float4 tSpace0 : TEXCOORD5;
+                float4 tSpace1 : TEXCOORD6;
+                float4 tSpace2 : TEXCOORD7;
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 				float4 screenPos : TEXCOORD8;
-				#endif
-				float4 ase_texcoord9 : TEXCOORD9;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+                #endif
+                float4 ase_texcoord9 : TEXCOORD9;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
 
-			#ifdef _TRANSMISSION_ASE
+            #ifdef _TRANSMISSION_ASE
 				float _TransmissionShadow;
-			#endif
-			#ifdef _TRANSLUCENCY_ASE
+            #endif
+            #ifdef _TRANSLUCENCY_ASE
 				float _TransStrength;
 				float _TransNormal;
 				float _TransScattering;
 				float _TransDirect;
 				float _TransAmbient;
 				float _TransShadow;
-			#endif
-			#ifdef TESSELLATION_ON
+            #endif
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			uniform sampler2D _MainTex;
-			uniform float4 _Color;
-			uniform sampler2D _BumpMap;
-			uniform float _BumpScale;
-			uniform sampler2D _EmissionMap;
-			uniform float _Metallic;
-			uniform float _Smoothness;
-			uniform float _Cutoff;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
-				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+            #endif
+            uniform sampler2D _MainTex;
+            uniform float4 _Color;
+            uniform sampler2D _BumpMap;
+            uniform float _BumpScale;
+            uniform sampler2D _EmissionMap;
+            uniform float _Metallic;
+            uniform float _Smoothness;
+            uniform float _Cutoff;
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
+                #define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
+                #define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
+                #define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
+                #define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Band)
+                #define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
+                #define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
+                #define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
+                #define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
+                #define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
-	
-			float3 HSVToRGB( float3 c )
-			{
-				float4 K = float4( 1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0 );
-				float3 p = abs( frac( c.xxx + K.xyz ) * 6.0 - K.www );
-				return c.z * lerp( K.xxx, saturate( p - K.xxx ), c.y );
-			}
-			
-			float3 RGBToHSV(float3 c)
-			{
-				float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-				float4 p = lerp( float4( c.bg, K.wz ), float4( c.gb, K.xy ), step( c.b, c.g ) );
-				float4 q = lerp( float4( p.xyw, c.r ), float4( c.r, p.yzx ), step( p.x, c.r ) );
-				float d = q.x - min( q.w, q.y );
-				float e = 1.0e-10;
-				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-			}
-			inline float AudioLinkLerp3_g8( int Band, float Delay )
-			{
-				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
-			}
-			
 
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+            float3 HSVToRGB(float3 c)
+            {
+                float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                float3 p = abs(frac(c.xxx + K.xyz) * 6.0 - K.www);
+                return c.z * lerp(K.xxx, saturate(p - K.xxx), c.y);
+            }
 
-				o.ase_texcoord9.xy = v.ase_texcoord.xy;
-				
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord9.zw = 0;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            float3 RGBToHSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            inline float AudioLinkLerp3_g8(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.ase_texcoord9.xy = v.ase_texcoord.xy;
+
+                //setting value to unused interpolator channels and avoid initialization warnings
+                o.ase_texcoord9.zw = 0;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				o.pos = UnityObjectToClipPos(v.vertex);
-				float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
-				fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
-				fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
-				fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
-				fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
-				o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
-				o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
-				o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
+                o.pos = UnityObjectToClipPos(v.vertex);
+                float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
+                fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
+                fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
+                fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
+                fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
+                o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
+                o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
+                o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
 
-				#if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201810 && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
 					UNITY_TRANSFER_LIGHTING(o, v.texcoord1.xy);
-				#elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					#if UNITY_VERSION >= 201710
+                #elif defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                #if UNITY_VERSION >= 201710
 						UNITY_TRANSFER_SHADOW(o, v.texcoord1.xy);
-					#else
-						TRANSFER_SHADOW(o);
-					#endif
-				#endif
+                #else
+                TRANSFER_SHADOW(o);
+                #endif
+                #endif
 
-				#ifdef ASE_FOG
-					UNITY_TRANSFER_FOG(o,o.pos);
-				#endif
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #ifdef ASE_FOG
+                UNITY_TRANSFER_FOG(o, o.pos);
+                #endif
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 					o.screenPos = ComputeScreenPos(o.pos);
-				#endif
-				return o;
-			}
+                #endif
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -948,15 +955,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -981,157 +988,165 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
 				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
-				#if defined(ASE_PHONG_TESSELLATION)
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
 
-			fixed4 frag ( v2f IN 
-				#ifdef _DEPTHOFFSET_ON
+            fixed4 frag(v2f IN
+                #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-				) : SV_Target 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
+                #endif
+            ) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
 
-				#ifdef LOD_FADE_CROSSFADE
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
-				float3 WorldTangent = float3(IN.tSpace0.x,IN.tSpace1.x,IN.tSpace2.x);
-				float3 WorldBiTangent = float3(IN.tSpace0.y,IN.tSpace1.y,IN.tSpace2.y);
-				float3 WorldNormal = float3(IN.tSpace0.z,IN.tSpace1.z,IN.tSpace2.z);
-				float3 worldPos = float3(IN.tSpace0.w,IN.tSpace1.w,IN.tSpace2.w);
-				float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
-				#if defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
-					UNITY_LIGHT_ATTENUATION(atten, IN, worldPos)
-				#else
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
+                float3 WorldTangent = float3(IN.tSpace0.x, IN.tSpace1.x, IN.tSpace2.x);
+                float3 WorldBiTangent = float3(IN.tSpace0.y, IN.tSpace1.y, IN.tSpace2.y);
+                float3 WorldNormal = float3(IN.tSpace0.z, IN.tSpace1.z, IN.tSpace2.z);
+                float3 worldPos = float3(IN.tSpace0.w, IN.tSpace1.w, IN.tSpace2.w);
+                float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
+                #if defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+                UNITY_LIGHT_ATTENUATION(atten, IN, worldPos)
+                #else
 					half atten = 1;
-				#endif
-				#if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
+                #endif
+                #if defined(ASE_NEEDS_FRAG_SCREEN_POSITION)
 				float4 ScreenPos = IN.screenPos;
-				#endif
+                #endif
 
 
-				float2 texCoord6 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2DNode4 * _Color ).rgb );
-				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
-				float hueShift33 = _AudioHueShift_Instance;
-				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g8 = (int)_Band_Instance;
-				float2 texCoord50 = IN.ase_texcoord9.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g10 = texCoord50;
-				float temp_output_5_0_g10 = ( break6_g10.x - 0.5 );
-				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g10 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g10 = cos( temp_output_2_0_g10 );
-				float temp_output_8_0_g10 = sin( temp_output_2_0_g10 );
-				float temp_output_20_0_g10 = ( 1.0 / ( abs( temp_output_3_0_g10 ) + abs( temp_output_8_0_g10 ) ) );
-				float temp_output_7_0_g10 = ( break6_g10.y - 0.5 );
-				float2 appendResult16_g10 = (float2(( ( ( temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) + ( temp_output_7_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) - ( temp_output_5_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 )));
-				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
-				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g8 = ( ( (_Delay_Instance + (( appendResult16_g10.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8( Band3_g8 , Delay3_g8 );
-				float temp_output_96_0 = localAudioLinkLerp3_g8;
-				float amplitude36 = temp_output_96_0;
-				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
-				
-				float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
-				float2 uv_BumpMap = IN.ase_texcoord9.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
-				
-				float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
-				float2 uv_EmissionMap = IN.ase_texcoord9.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
-				float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
-				float3 hsvTorgb40 = RGBToHSV( ( tex2D( _EmissionMap, uv_EmissionMap ) * _EmissionColor_Instance * temp_output_96_0 ).rgb );
-				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
-				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
-				
-				float alpha98 = tex2DNode4.a;
-				
-				o.Albedo = hsvTorgb39;
-				o.Normal = ( UnpackNormal( tex2D( _BumpMap, uv_BumpMap ) ) * _BumpScale );
-				o.Emission = ( hsvTorgb45 * _Emission_Instance );
-				#if defined(_SPECULAR_SETUP)
+                float2 texCoord6 = IN.ase_texcoord9.xy * float2(1, 1) + float2(0, 0);
+                float4 tex2DNode4 = tex2D(_MainTex, texCoord6);
+                float3 hsvTorgb32 = RGBToHSV((tex2DNode4 * _Color).rgb);
+                float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
+                float hueShift33 = _AudioHueShift_Instance;
+                float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
+                int Band3_g8 = (int)_Band_Instance;
+                float2 texCoord50 = IN.ase_texcoord9.xy * float2(1, 1) + float2(0, 0);
+                float2 break6_g10 = texCoord50;
+                float temp_output_5_0_g10 = (break6_g10.x - 0.5);
+                float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
+                float temp_output_2_0_g10 = radians(_PulseRotation_Instance);
+                float temp_output_3_0_g10 = cos(temp_output_2_0_g10);
+                float temp_output_8_0_g10 = sin(temp_output_2_0_g10);
+                float temp_output_20_0_g10 = (1.0 / (abs(temp_output_3_0_g10) + abs(temp_output_8_0_g10)));
+                float temp_output_7_0_g10 = (break6_g10.y - 0.5);
+                float2 appendResult16_g10 = (float2(
+                    (((temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10) + (temp_output_7_0_g10 *
+                        temp_output_8_0_g10 * temp_output_20_0_g10)) + 0.5),
+                    (((temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10) - (temp_output_5_0_g10 *
+                        temp_output_8_0_g10 * temp_output_20_0_g10)) + 0.5)));
+                float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
+                float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
+                float Delay3_g8 = (((_Delay_Instance + ((appendResult16_g10.x * _Pulse_Instance) - 0.0) * (1.0 -
+                    _Delay_Instance) / (1.0 - 0.0)) % 1.0) * 128.0);
+                float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8(Band3_g8, Delay3_g8);
+                float temp_output_96_0 = localAudioLinkLerp3_g8;
+                float amplitude36 = temp_output_96_0;
+                float3 hsvTorgb39 = HSVToRGB(float3((hsvTorgb32.x + (hueShift33 * amplitude36)), hsvTorgb32.y,
+                                                                           hsvTorgb32.z));
+
+                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
+                float2 uv_BumpMap = IN.ase_texcoord9.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
+
+                float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
+                float2 uv_EmissionMap = IN.ase_texcoord9.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
+                float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
+                float3 hsvTorgb40 = RGBToHSV(
+                    (tex2D(_EmissionMap, uv_EmissionMap) * _EmissionColor_Instance * temp_output_96_0).rgb);
+                float3 hsvTorgb45 = HSVToRGB(float3((hsvTorgb40.x + (hueShift33 * amplitude36)), hsvTorgb40.y,
+                                    hsvTorgb40.z));
+                float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
+
+                float alpha98 = tex2DNode4.a;
+
+                o.Albedo = hsvTorgb39;
+                o.Normal = (UnpackNormal(tex2D(_BumpMap, uv_BumpMap)) * _BumpScale);
+                o.Emission = (hsvTorgb45 * _Emission_Instance);
+                #if defined(_SPECULAR_SETUP)
 					o.Specular = fixed3( 0, 0, 0 );
-				#else
-					o.Metallic = _Metallic;
-				#endif
-				o.Smoothness = _Smoothness;
-				o.Occlusion = 1;
-				o.Alpha = alpha98;
-				float AlphaClipThreshold = _Cutoff;
-				float3 Transmission = 1;
-				float3 Translucency = 1;		
+                #else
+                o.Metallic = _Metallic;
+                #endif
+                o.Smoothness = _Smoothness;
+                o.Occlusion = 1;
+                o.Alpha = alpha98;
+                float AlphaClipThreshold = _Cutoff;
+                float3 Transmission = 1;
+                float3 Translucency = 1;
 
-				#ifdef _ALPHATEST_ON
-					clip( o.Alpha - AlphaClipThreshold );
-				#endif
+                #ifdef _ALPHATEST_ON
+                clip(o.Alpha - AlphaClipThreshold);
+                #endif
 
-				#ifdef _DEPTHOFFSET_ON
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				#ifndef USING_DIRECTIONAL_LIGHT
-					fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
-				#else
+                #ifndef USING_DIRECTIONAL_LIGHT
+                fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
+                #else
 					fixed3 lightDir = _WorldSpaceLightPos0.xyz;
-				#endif
+                #endif
 
-				fixed4 c = 0;
-				float3 worldN;
-				worldN.x = dot(IN.tSpace0.xyz, o.Normal);
-				worldN.y = dot(IN.tSpace1.xyz, o.Normal);
-				worldN.z = dot(IN.tSpace2.xyz, o.Normal);
-				worldN = normalize(worldN);
-				o.Normal = worldN;
+                fixed4 c = 0;
+                float3 worldN;
+                worldN.x = dot(IN.tSpace0.xyz, o.Normal);
+                worldN.y = dot(IN.tSpace1.xyz, o.Normal);
+                worldN.z = dot(IN.tSpace2.xyz, o.Normal);
+                worldN = normalize(worldN);
+                o.Normal = worldN;
 
-				UnityGI gi;
-				UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
-				gi.indirect.diffuse = 0;
-				gi.indirect.specular = 0;
-				gi.light.color = _LightColor0.rgb;
-				gi.light.dir = lightDir;
-				gi.light.color *= atten;
+                UnityGI gi;
+                UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
+                gi.indirect.diffuse = 0;
+                gi.indirect.specular = 0;
+                gi.light.color = _LightColor0.rgb;
+                gi.light.dir = lightDir;
+                gi.light.color *= atten;
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					c += LightingStandardSpecular( o, worldViewDir, gi );
-				#else
-					c += LightingStandard( o, worldViewDir, gi );
-				#endif
-				
-				#ifdef _TRANSMISSION_ASE
+                #else
+                c += LightingStandard(o, worldViewDir, gi);
+                #endif
+
+                #ifdef _TRANSMISSION_ASE
 				{
 					float shadow = _TransmissionShadow;
-					#ifdef DIRECTIONAL
+                #ifdef DIRECTIONAL
 						float3 lightAtten = lerp( _LightColor0.rgb, gi.light.color, shadow );
-					#else
+                #else
 						float3 lightAtten = gi.light.color;
-					#endif
+                #endif
 					half3 transmission = max(0 , -dot(o.Normal, gi.light.dir)) * lightAtten * Transmission;
 					c.rgb += o.Albedo * transmission;
 				}
-				#endif
+                #endif
 
-				#ifdef _TRANSLUCENCY_ASE
+                #ifdef _TRANSLUCENCY_ASE
 				{
 					float shadow = _TransShadow;
 					float normal = _TransNormal;
@@ -1140,237 +1155,244 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 					float ambient = _TransAmbient;
 					float strength = _TransStrength;
 
-					#ifdef DIRECTIONAL
+                #ifdef DIRECTIONAL
 						float3 lightAtten = lerp( _LightColor0.rgb, gi.light.color, shadow );
-					#else
+                #else
 						float3 lightAtten = gi.light.color;
-					#endif
+                #endif
 					half3 lightDir = gi.light.dir + o.Normal * normal;
 					half transVdotL = pow( saturate( dot( worldViewDir, -lightDir ) ), scattering );
 					half3 translucency = lightAtten * (transVdotL * direct + gi.indirect.diffuse * ambient) * Translucency;
 					c.rgb += o.Albedo * translucency * strength;
 				}
-				#endif
+                #endif
 
-				//#ifdef _REFRACTION_ASE
-				//	float4 projScreenPos = ScreenPos / ScreenPos.w;
-				//	float3 refractionOffset = ( RefractionIndex - 1.0 ) * mul( UNITY_MATRIX_V, WorldNormal ).xyz * ( 1.0 - dot( WorldNormal, WorldViewDirection ) );
-				//	projScreenPos.xy += refractionOffset.xy;
-				//	float3 refraction = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _GrabTexture, projScreenPos ) * RefractionColor;
-				//	color.rgb = lerp( refraction, color.rgb, color.a );
-				//	color.a = 1;
-				//#endif
+                //#ifdef _REFRACTION_ASE
+                //	float4 projScreenPos = ScreenPos / ScreenPos.w;
+                //	float3 refractionOffset = ( RefractionIndex - 1.0 ) * mul( UNITY_MATRIX_V, WorldNormal ).xyz * ( 1.0 - dot( WorldNormal, WorldViewDirection ) );
+                //	projScreenPos.xy += refractionOffset.xy;
+                //	float3 refraction = UNITY_SAMPLE_SCREENSPACE_TEXTURE( _GrabTexture, projScreenPos ) * RefractionColor;
+                //	color.rgb = lerp( refraction, color.rgb, color.a );
+                //	color.a = 1;
+                //#endif
 
-				#ifdef ASE_FOG
-					UNITY_APPLY_FOG(IN.fogCoord, c);
-				#endif
-				return c;
-			}
-			ENDCG
-		}
+                #ifdef ASE_FOG
+                UNITY_APPLY_FOG(IN.fogCoord, c);
+                #endif
+                return c;
+            }
+            ENDCG
+        }
 
-		
-		Pass
-		{
-			
-			Name "Deferred"
-			Tags { "LightMode"="Deferred" }
 
-			AlphaToMask Off
+        Pass
+        {
 
-			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
-			#define _ALPHATEST_ON 1
+            Name "Deferred"
+            Tags
+            {
+                "LightMode"="Deferred"
+            }
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma target 3.0
-			#pragma exclude_renderers nomrt
-			#pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
-			#pragma multi_compile_prepassfinal
-			#ifndef UNITY_PASS_DEFERRED
-				#define UNITY_PASS_DEFERRED
-			#endif
-			#include "HLSLSupport.cginc"
-			#if !defined( UNITY_INSTANCED_LOD_FADE )
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#if !defined( UNITY_INSTANCED_SH )
-				#define UNITY_INSTANCED_SH
-			#endif
-			#if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            AlphaToMask Off
 
-			#pragma multi_compile_instancing
+            CGPROGRAM
+            #define _ALPHABLEND_ON 1
+            #define UNITY_STANDARD_USE_DITHER_MASK 1
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
+            #define _ALPHATEST_ON 1
 
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 3.0
+            #pragma exclude_renderers nomrt
+            #pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
+            #pragma multi_compile_prepassfinal
+            #ifndef UNITY_PASS_DEFERRED
+            #define UNITY_PASS_DEFERRED
+            #endif
+            #include "HLSLSupport.cginc"
+            #if !defined( UNITY_INSTANCED_LOD_FADE )
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #if !defined( UNITY_INSTANCED_SH )
+            #define UNITY_INSTANCED_SH
+            #endif
+            #if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
 
-			struct v2f {
-				#if UNITY_VERSION >= 201810
+            #pragma multi_compile_instancing
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+                float4 ase_texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                #if UNITY_VERSION >= 201810
 					UNITY_POSITION(pos);
-				#else
-					float4 pos : SV_POSITION;
-				#endif
-				float4 lmap : TEXCOORD2;
-				#ifndef LIGHTMAP_ON
-					#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #else
+                float4 pos : SV_POSITION;
+                #endif
+                float4 lmap : TEXCOORD2;
+                #ifndef LIGHTMAP_ON
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 						half3 sh : TEXCOORD3;
-					#endif
-				#else
-					#ifdef DIRLIGHTMAP_OFF
+                #endif
+                #else
+                #ifdef DIRLIGHTMAP_OFF
 						float4 lmapFadePos : TEXCOORD4;
-					#endif
-				#endif
-				float4 tSpace0 : TEXCOORD5;
-				float4 tSpace1 : TEXCOORD6;
-				float4 tSpace2 : TEXCOORD7;
-				float4 ase_texcoord8 : TEXCOORD8;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+                #endif
+                #endif
+                float4 tSpace0 : TEXCOORD5;
+                float4 tSpace1 : TEXCOORD6;
+                float4 tSpace2 : TEXCOORD7;
+                float4 ase_texcoord8 : TEXCOORD8;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
 
-			#ifdef LIGHTMAP_ON
+            #ifdef LIGHTMAP_ON
 			float4 unity_LightmapFade;
-			#endif
-			fixed4 unity_Ambient;
-			#ifdef TESSELLATION_ON
+            #endif
+            fixed4 unity_Ambient;
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			uniform sampler2D _MainTex;
-			uniform float4 _Color;
-			uniform sampler2D _BumpMap;
-			uniform float _BumpScale;
-			uniform sampler2D _EmissionMap;
-			uniform float _Metallic;
-			uniform float _Smoothness;
-			uniform float _Cutoff;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
-				UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
-#define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+            #endif
+            uniform sampler2D _MainTex;
+            uniform float4 _Color;
+            uniform sampler2D _BumpMap;
+            uniform float _BumpScale;
+            uniform sampler2D _EmissionMap;
+            uniform float _Metallic;
+            uniform float _Smoothness;
+            uniform float _Cutoff;
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
+                #define _BumpMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
+                #define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
+                #define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
+                #define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Band)
+                #define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
+                #define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
+                #define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
+                #define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
+                #define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
-	
-			float3 HSVToRGB( float3 c )
-			{
-				float4 K = float4( 1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0 );
-				float3 p = abs( frac( c.xxx + K.xyz ) * 6.0 - K.www );
-				return c.z * lerp( K.xxx, saturate( p - K.xxx ), c.y );
-			}
-			
-			float3 RGBToHSV(float3 c)
-			{
-				float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-				float4 p = lerp( float4( c.bg, K.wz ), float4( c.gb, K.xy ), step( c.b, c.g ) );
-				float4 q = lerp( float4( p.xyw, c.r ), float4( c.r, p.yzx ), step( p.x, c.r ) );
-				float d = q.x - min( q.w, q.y );
-				float e = 1.0e-10;
-				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-			}
-			inline float AudioLinkLerp3_g8( int Band, float Delay )
-			{
-				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
-			}
-			
 
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+            float3 HSVToRGB(float3 c)
+            {
+                float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                float3 p = abs(frac(c.xxx + K.xyz) * 6.0 - K.www);
+                return c.z * lerp(K.xxx, saturate(p - K.xxx), c.y);
+            }
 
-				o.ase_texcoord8.xy = v.ase_texcoord.xy;
-				
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord8.zw = 0;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            float3 RGBToHSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            inline float AudioLinkLerp3_g8(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                    UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.ase_texcoord8.xy = v.ase_texcoord.xy;
+
+                //setting value to unused interpolator channels and avoid initialization warnings
+                o.ase_texcoord8.zw = 0;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				o.pos = UnityObjectToClipPos(v.vertex);
-				float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
-				fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
-				fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
-				fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
-				fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
-				o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
-				o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
-				o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
+                o.pos = UnityObjectToClipPos(v.vertex);
+                float3 worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
+                fixed3 worldNormal = UnityObjectToWorldNormal(v.normal);
+                fixed3 worldTangent = UnityObjectToWorldDir(v.tangent.xyz);
+                fixed tangentSign = v.tangent.w * unity_WorldTransformParams.w;
+                fixed3 worldBinormal = cross(worldNormal, worldTangent) * tangentSign;
+                o.tSpace0 = float4(worldTangent.x, worldBinormal.x, worldNormal.x, worldPos.x);
+                o.tSpace1 = float4(worldTangent.y, worldBinormal.y, worldNormal.y, worldPos.y);
+                o.tSpace2 = float4(worldTangent.z, worldBinormal.z, worldNormal.z, worldPos.z);
 
-				#ifdef DYNAMICLIGHTMAP_ON
+                #ifdef DYNAMICLIGHTMAP_ON
 					o.lmap.zw = v.texcoord2.xy * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
-				#else
-					o.lmap.zw = 0;
-				#endif
-				#ifdef LIGHTMAP_ON
+                #else
+                o.lmap.zw = 0;
+                #endif
+                #ifdef LIGHTMAP_ON
 					o.lmap.xy = v.texcoord1.xy * unity_LightmapST.xy + unity_LightmapST.zw;
-					#ifdef DIRLIGHTMAP_OFF
+                #ifdef DIRLIGHTMAP_OFF
 						o.lmapFadePos.xyz = (mul(unity_ObjectToWorld, v.vertex).xyz - unity_ShadowFadeCenterAndType.xyz) * unity_ShadowFadeCenterAndType.w;
 						o.lmapFadePos.w = (-UnityObjectToViewPos(v.vertex).z) * (1.0 - unity_ShadowFadeCenterAndType.w);
-					#endif
-				#else
-					o.lmap.xy = 0;
-					#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #endif
+                #else
+                o.lmap.xy = 0;
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 						o.sh = 0;
 						o.sh = ShadeSHPerVertex (worldNormal, o.sh);
-					#endif
-				#endif
-				return o;
-			}
+                #endif
+                #endif
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -1409,15 +1431,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -1442,341 +1464,357 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
 				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
-				#if defined(ASE_PHONG_TESSELLATION)
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
 
-			void frag (v2f IN 
-				, out half4 outGBuffer0 : SV_Target0
-				, out half4 outGBuffer1 : SV_Target1
-				, out half4 outGBuffer2 : SV_Target2
-				, out half4 outEmission : SV_Target3
-				#if defined(SHADOWS_SHADOWMASK) && (UNITY_ALLOWED_MRT_COUNT > 4)
+            void frag(v2f IN
+                                                                  , out half4 outGBuffer0 : SV_Target0
+                                                                  , out half4 outGBuffer1 : SV_Target1
+                                                                  , out half4 outGBuffer2 : SV_Target2
+                                                                  , out half4 outEmission : SV_Target3
+                                                                  #if defined(SHADOWS_SHADOWMASK) && (UNITY_ALLOWED_MRT_COUNT > 4)
 				, out half4 outShadowMask : SV_Target4
-				#endif
-				#ifdef _DEPTHOFFSET_ON
+                                                                  #endif
+                                                                  #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-			) 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
+                                                                  #endif
+            )
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
 
-				#ifdef LOD_FADE_CROSSFADE
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
-				float3 WorldTangent = float3(IN.tSpace0.x,IN.tSpace1.x,IN.tSpace2.x);
-				float3 WorldBiTangent = float3(IN.tSpace0.y,IN.tSpace1.y,IN.tSpace2.y);
-				float3 WorldNormal = float3(IN.tSpace0.z,IN.tSpace1.z,IN.tSpace2.z);
-				float3 worldPos = float3(IN.tSpace0.w,IN.tSpace1.w,IN.tSpace2.w);
-				float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
-				half atten = 1;
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
+                float3 WorldTangent = float3(IN.tSpace0.x, IN.tSpace1.x, IN.tSpace2.x);
+                float3 WorldBiTangent = float3(IN.tSpace0.y, IN.tSpace1.y, IN.tSpace2.y);
+                float3 WorldNormal = float3(IN.tSpace0.z, IN.tSpace1.z, IN.tSpace2.z);
+                float3 worldPos = float3(IN.tSpace0.w, IN.tSpace1.w, IN.tSpace2.w);
+                float3 worldViewDir = normalize(UnityWorldSpaceViewDir(worldPos));
+                half atten = 1;
 
-				float2 texCoord6 = IN.ase_texcoord8.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2DNode4 * _Color ).rgb );
-				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
-				float hueShift33 = _AudioHueShift_Instance;
-				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g8 = (int)_Band_Instance;
-				float2 texCoord50 = IN.ase_texcoord8.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g10 = texCoord50;
-				float temp_output_5_0_g10 = ( break6_g10.x - 0.5 );
-				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g10 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g10 = cos( temp_output_2_0_g10 );
-				float temp_output_8_0_g10 = sin( temp_output_2_0_g10 );
-				float temp_output_20_0_g10 = ( 1.0 / ( abs( temp_output_3_0_g10 ) + abs( temp_output_8_0_g10 ) ) );
-				float temp_output_7_0_g10 = ( break6_g10.y - 0.5 );
-				float2 appendResult16_g10 = (float2(( ( ( temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) + ( temp_output_7_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) - ( temp_output_5_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 )));
-				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
-				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g8 = ( ( (_Delay_Instance + (( appendResult16_g10.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8( Band3_g8 , Delay3_g8 );
-				float temp_output_96_0 = localAudioLinkLerp3_g8;
-				float amplitude36 = temp_output_96_0;
-				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
-				
-				float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
-				float2 uv_BumpMap = IN.ase_texcoord8.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
-				
-				float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
-				float2 uv_EmissionMap = IN.ase_texcoord8.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
-				float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
-				float3 hsvTorgb40 = RGBToHSV( ( tex2D( _EmissionMap, uv_EmissionMap ) * _EmissionColor_Instance * temp_output_96_0 ).rgb );
-				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
-				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
-				
-				float alpha98 = tex2DNode4.a;
-				
-				o.Albedo = hsvTorgb39;
-				o.Normal = ( UnpackNormal( tex2D( _BumpMap, uv_BumpMap ) ) * _BumpScale );
-				o.Emission = ( hsvTorgb45 * _Emission_Instance );
-				#if defined(_SPECULAR_SETUP)
+                float2 texCoord6 = IN.ase_texcoord8.xy * float2(1, 1) + float2(0, 0);
+                float4 tex2DNode4 = tex2D(_MainTex, texCoord6);
+                float3 hsvTorgb32 = RGBToHSV((tex2DNode4 * _Color).rgb);
+                float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
+                float hueShift33 = _AudioHueShift_Instance;
+                float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
+                int Band3_g8 = (int)_Band_Instance;
+                float2 texCoord50 = IN.ase_texcoord8.xy * float2(1, 1) + float2(0, 0);
+                float2 break6_g10 = texCoord50;
+                float temp_output_5_0_g10 = (break6_g10.x - 0.5);
+                float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
+                float temp_output_2_0_g10 = radians(_PulseRotation_Instance);
+                float temp_output_3_0_g10 = cos(temp_output_2_0_g10);
+                float temp_output_8_0_g10 = sin(temp_output_2_0_g10);
+                float temp_output_20_0_g10 = (1.0 / (abs(temp_output_3_0_g10) + abs(temp_output_8_0_g10)));
+                float temp_output_7_0_g10 = (break6_g10.y - 0.5);
+                float2 appendResult16_g10 = (float2(
+                    (((temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10) + (temp_output_7_0_g10 *
+                        temp_output_8_0_g10 * temp_output_20_0_g10)) + 0.5),
+                    (((temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10) - (temp_output_5_0_g10 *
+                        temp_output_8_0_g10 * temp_output_20_0_g10)) + 0.5)));
+                float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
+                float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
+                float Delay3_g8 = (((_Delay_Instance + ((appendResult16_g10.x * _Pulse_Instance) - 0.0) * (1.0 -
+                    _Delay_Instance) / (1.0 - 0.0)) % 1.0) * 128.0);
+                float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8(Band3_g8, Delay3_g8);
+                float temp_output_96_0 = localAudioLinkLerp3_g8;
+                float amplitude36 = temp_output_96_0;
+                float3 hsvTorgb39 = HSVToRGB(float3((hsvTorgb32.x + (hueShift33 * amplitude36)), hsvTorgb32.y,
+        hsvTorgb32.z));
+
+                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_BumpMap_ST_arr, _BumpMap_ST);
+                float2 uv_BumpMap = IN.ase_texcoord8.xy * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
+
+                float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
+                float2 uv_EmissionMap = IN.ase_texcoord8.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
+                float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
+                float3 hsvTorgb40 = RGBToHSV(
+                    (tex2D(_EmissionMap, uv_EmissionMap) * _EmissionColor_Instance * temp_output_96_0).rgb);
+                float3 hsvTorgb45 = HSVToRGB(float3((hsvTorgb40.x + (hueShift33 * amplitude36)), hsvTorgb40.y,
+                    hsvTorgb40.z));
+                float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
+
+                float alpha98 = tex2DNode4.a;
+
+                o.Albedo = hsvTorgb39;
+                o.Normal = (UnpackNormal(tex2D(_BumpMap, uv_BumpMap)) * _BumpScale);
+                o.Emission = (hsvTorgb45 * _Emission_Instance);
+                #if defined(_SPECULAR_SETUP)
 					o.Specular = fixed3( 0, 0, 0 );
-				#else
-					o.Metallic = _Metallic;
-				#endif
-				o.Smoothness = _Smoothness;
-				o.Occlusion = 1;
-				o.Alpha = alpha98;
-				float AlphaClipThreshold = _Cutoff;
-				float3 BakedGI = 0;
+                #else
+                o.Metallic = _Metallic;
+                #endif
+                o.Smoothness = _Smoothness;
+                o.Occlusion = 1;
+                o.Alpha = alpha98;
+                float AlphaClipThreshold = _Cutoff;
+                float3 BakedGI = 0;
 
-				#ifdef _ALPHATEST_ON
-					clip( o.Alpha - AlphaClipThreshold );
-				#endif
+                #ifdef _ALPHATEST_ON
+                clip(o.Alpha - AlphaClipThreshold);
+                #endif
 
-				#ifdef _DEPTHOFFSET_ON
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				#ifndef USING_DIRECTIONAL_LIGHT
-					fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
-				#else
+                #ifndef USING_DIRECTIONAL_LIGHT
+                fixed3 lightDir = normalize(UnityWorldSpaceLightDir(worldPos));
+                #else
 					fixed3 lightDir = _WorldSpaceLightPos0.xyz;
-				#endif
+                #endif
 
-				float3 worldN;
-				worldN.x = dot(IN.tSpace0.xyz, o.Normal);
-				worldN.y = dot(IN.tSpace1.xyz, o.Normal);
-				worldN.z = dot(IN.tSpace2.xyz, o.Normal);
-				worldN = normalize(worldN);
-				o.Normal = worldN;
+                float3 worldN;
+                worldN.x = dot(IN.tSpace0.xyz, o.Normal);
+                worldN.y = dot(IN.tSpace1.xyz, o.Normal);
+                worldN.z = dot(IN.tSpace2.xyz, o.Normal);
+                worldN = normalize(worldN);
+                o.Normal = worldN;
 
-				UnityGI gi;
-				UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
-				gi.indirect.diffuse = 0;
-				gi.indirect.specular = 0;
-				gi.light.color = 0;
-				gi.light.dir = half3(0,1,0);
+                UnityGI gi;
+                UNITY_INITIALIZE_OUTPUT(UnityGI, gi);
+                gi.indirect.diffuse = 0;
+                gi.indirect.specular = 0;
+                gi.light.color = 0;
+                gi.light.dir = half3(0, 1, 0);
 
-				UnityGIInput giInput;
-				UNITY_INITIALIZE_OUTPUT(UnityGIInput, giInput);
-				giInput.light = gi.light;
-				giInput.worldPos = worldPos;
-				giInput.worldViewDir = worldViewDir;
-				giInput.atten = atten;
-				#if defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)
+                UnityGIInput giInput;
+                UNITY_INITIALIZE_OUTPUT(UnityGIInput, giInput);
+                giInput.light = gi.light;
+                giInput.worldPos = worldPos;
+                giInput.worldViewDir = worldViewDir;
+                giInput.atten = atten;
+                #if defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)
 					giInput.lightmapUV = IN.lmap;
-				#else
-					giInput.lightmapUV = 0.0;
-				#endif
-				#if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
+                #else
+                giInput.lightmapUV = 0.0;
+                #endif
+                #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
 					giInput.ambient = IN.sh;
-				#else
-					giInput.ambient.rgb = 0.0;
-				#endif
-				giInput.probeHDR[0] = unity_SpecCube0_HDR;
-				giInput.probeHDR[1] = unity_SpecCube1_HDR;
-				#if defined(UNITY_SPECCUBE_BLENDING) || defined(UNITY_SPECCUBE_BOX_PROJECTION)
+                #else
+                giInput.ambient.rgb = 0.0;
+                #endif
+                giInput.probeHDR[0] = unity_SpecCube0_HDR;
+                giInput.probeHDR[1] = unity_SpecCube1_HDR;
+                #if defined(UNITY_SPECCUBE_BLENDING) || defined(UNITY_SPECCUBE_BOX_PROJECTION)
 					giInput.boxMin[0] = unity_SpecCube0_BoxMin;
-				#endif
-				#ifdef UNITY_SPECCUBE_BOX_PROJECTION
+                #endif
+                #ifdef UNITY_SPECCUBE_BOX_PROJECTION
 					giInput.boxMax[0] = unity_SpecCube0_BoxMax;
 					giInput.probePosition[0] = unity_SpecCube0_ProbePosition;
 					giInput.boxMax[1] = unity_SpecCube1_BoxMax;
 					giInput.boxMin[1] = unity_SpecCube1_BoxMin;
 					giInput.probePosition[1] = unity_SpecCube1_ProbePosition;
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					LightingStandardSpecular_GI( o, giInput, gi );
-				#else
-					LightingStandard_GI( o, giInput, gi );
-				#endif
+                #else
+                LightingStandard_GI(o, giInput, gi);
+                #endif
 
-				#ifdef ASE_BAKEDGI
+                #ifdef ASE_BAKEDGI
 					gi.indirect.diffuse = BakedGI;
-				#endif
+                #endif
 
-				#if UNITY_SHOULD_SAMPLE_SH && !defined(LIGHTMAP_ON) && defined(ASE_NO_AMBIENT)
+                #if UNITY_SHOULD_SAMPLE_SH && !defined(LIGHTMAP_ON) && defined(ASE_NO_AMBIENT)
 					gi.indirect.diffuse = 0;
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					outEmission = LightingStandardSpecular_Deferred( o, worldViewDir, gi, outGBuffer0, outGBuffer1, outGBuffer2 );
-				#else
-					outEmission = LightingStandard_Deferred( o, worldViewDir, gi, outGBuffer0, outGBuffer1, outGBuffer2 );
-				#endif
+                #else
+                outEmission = LightingStandard_Deferred(o, worldViewDir, gi, outGBuffer0, outGBuffer1, outGBuffer2);
+                #endif
 
-				#if defined(SHADOWS_SHADOWMASK) && (UNITY_ALLOWED_MRT_COUNT > 4)
+                #if defined(SHADOWS_SHADOWMASK) && (UNITY_ALLOWED_MRT_COUNT > 4)
 					outShadowMask = UnityGetRawBakedOcclusions (IN.lmap.xy, float3(0, 0, 0));
-				#endif
-				#ifndef UNITY_HDR_ON
-					outEmission.rgb = exp2(-outEmission.rgb);
-				#endif
-			}
-			ENDCG
-		}
+                #endif
+                #ifndef UNITY_HDR_ON
+                outEmission.rgb = exp2(-outEmission.rgb);
+                #endif
+            }
+            ENDCG
+        }
 
-		
-		Pass
-		{
-			
-			Name "Meta"
-			Tags { "LightMode"="Meta" }
-			Cull Off
 
-			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
-			#define _ALPHATEST_ON 1
+        Pass
+        {
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
-			#pragma shader_feature EDITOR_VISUALIZATION
-			#ifndef UNITY_PASS_META
-				#define UNITY_PASS_META
-			#endif
-			#include "HLSLSupport.cginc"
-			#if !defined( UNITY_INSTANCED_LOD_FADE )
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#if !defined( UNITY_INSTANCED_SH )
-				#define UNITY_INSTANCED_SH
-			#endif
-			#if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "UnityMetaPass.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            Name "Meta"
+            Tags
+            {
+                "LightMode"="Meta"
+            }
+            Cull Off
 
-			#pragma multi_compile_instancing
+            CGPROGRAM
+            #define _ALPHABLEND_ON 1
+            #define UNITY_STANDARD_USE_DITHER_MASK 1
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
+            #define _ALPHATEST_ON 1
 
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
-			struct v2f {
-				#if UNITY_VERSION >= 201810
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
+            #pragma shader_feature EDITOR_VISUALIZATION
+            #ifndef UNITY_PASS_META
+            #define UNITY_PASS_META
+            #endif
+            #include "HLSLSupport.cginc"
+            #if !defined( UNITY_INSTANCED_LOD_FADE )
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #if !defined( UNITY_INSTANCED_SH )
+            #define UNITY_INSTANCED_SH
+            #endif
+            #if !defined( UNITY_INSTANCED_LIGHTMAPSTS )
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "UnityMetaPass.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+            #pragma multi_compile_instancing
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+                float4 ase_texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                #if UNITY_VERSION >= 201810
 					UNITY_POSITION(pos);
-				#else
-					float4 pos : SV_POSITION;
-				#endif
-				#ifdef EDITOR_VISUALIZATION
+                #else
+                float4 pos : SV_POSITION;
+                #endif
+                #ifdef EDITOR_VISUALIZATION
 					float2 vizUV : TEXCOORD1;
 					float4 lightCoord : TEXCOORD2;
-				#endif
-				float4 ase_texcoord3 : TEXCOORD3;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+                #endif
+                float4 ase_texcoord3 : TEXCOORD3;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
 
-			#ifdef TESSELLATION_ON
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			uniform sampler2D _MainTex;
-			uniform float4 _Color;
-			uniform sampler2D _EmissionMap;
-			uniform float _Cutoff;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
-#define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
-#define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
-#define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Band)
-#define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
-#define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
-#define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
-#define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-				UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
-#define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+            #endif
+            uniform sampler2D _MainTex;
+            uniform float4 _Color;
+            uniform sampler2D _EmissionMap;
+            uniform float _Cutoff;
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionMap_ST)
+                #define _EmissionMap_ST_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float4, _EmissionColor)
+                #define _EmissionColor_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _AudioHueShift)
+                #define _AudioHueShift_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Band)
+                #define _Band_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _PulseRotation)
+                #define _PulseRotation_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Pulse)
+                #define _Pulse_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
+                #define _Delay_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+                UNITY_DEFINE_INSTANCED_PROP(float, _Emission)
+                #define _Emission_arr AudioLinkSurfaceAudioReactiveSurface_Cutout
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
-	
-			float3 HSVToRGB( float3 c )
-			{
-				float4 K = float4( 1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0 );
-				float3 p = abs( frac( c.xxx + K.xyz ) * 6.0 - K.www );
-				return c.z * lerp( K.xxx, saturate( p - K.xxx ), c.y );
-			}
-			
-			float3 RGBToHSV(float3 c)
-			{
-				float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-				float4 p = lerp( float4( c.bg, K.wz ), float4( c.gb, K.xy ), step( c.b, c.g ) );
-				float4 q = lerp( float4( p.xyw, c.r ), float4( c.r, p.yzx ), step( p.x, c.r ) );
-				float d = q.x - min( q.w, q.y );
-				float e = 1.0e-10;
-				return float3( abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-			}
-			inline float AudioLinkLerp3_g8( int Band, float Delay )
-			{
-				return AudioLinkLerp( ALPASS_AUDIOLINK + float2( Delay, Band ) ).r;
-			}
-			
 
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+            float3 HSVToRGB(float3 c)
+            {
+                float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                float3 p = abs(frac(c.xxx + K.xyz) * 6.0 - K.www);
+                return c.z * lerp(K.xxx, saturate(p - K.xxx), c.y);
+            }
 
-				o.ase_texcoord3.xy = v.ase_texcoord.xy;
-				
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord3.zw = 0;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            float3 RGBToHSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            inline float AudioLinkLerp3_g8(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                    UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.ase_texcoord3.xy = v.ase_texcoord.xy;
+
+                //setting value to unused interpolator channels and avoid initialization warnings
+                o.ase_texcoord3.zw = 0;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				#ifdef EDITOR_VISUALIZATION
+                #ifdef EDITOR_VISUALIZATION
 					o.vizUV = 0;
 					o.lightCoord = 0;
 					if (unity_VisualizationMode == EDITORVIZ_TEXTURE)
@@ -1786,14 +1824,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 						o.vizUV = v.texcoord1.xy * unity_LightmapST.xy + unity_LightmapST.zw;
 						o.lightCoord = mul(unity_EditorViz_WorldToLight, mul(unity_ObjectToWorld, float4(v.vertex.xyz, 1)));
 					}
-				#endif
+                #endif
 
-				o.pos = UnityMetaVertexPosition(v.vertex, v.texcoord1.xy, v.texcoord2.xy, unity_LightmapST, unity_DynamicLightmapST);
+                o.pos = UnityMetaVertexPosition(v.vertex, v.texcoord1.xy, v.texcoord2.xy, unity_LightmapST,
+                                              unity_DynamicLightmapST);
 
-				return o;
-			}
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -1832,15 +1871,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -1865,215 +1904,228 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
 				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
-				#if defined(ASE_PHONG_TESSELLATION)
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
 
-			fixed4 frag (v2f IN 
-				#ifdef _DEPTHOFFSET_ON
+            fixed4 frag(v2f IN
+                #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-				) : SV_Target 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
-				
-				#ifdef LOD_FADE_CROSSFADE
+                #endif
+            ) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
+
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
-				
-				float2 texCoord6 = IN.ase_texcoord3.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float3 hsvTorgb32 = RGBToHSV( ( tex2DNode4 * _Color ).rgb );
-				float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
-				float hueShift33 = _AudioHueShift_Instance;
-				float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
-				int Band3_g8 = (int)_Band_Instance;
-				float2 texCoord50 = IN.ase_texcoord3.xy * float2( 1,1 ) + float2( 0,0 );
-				float2 break6_g10 = texCoord50;
-				float temp_output_5_0_g10 = ( break6_g10.x - 0.5 );
-				float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
-				float temp_output_2_0_g10 = radians( _PulseRotation_Instance );
-				float temp_output_3_0_g10 = cos( temp_output_2_0_g10 );
-				float temp_output_8_0_g10 = sin( temp_output_2_0_g10 );
-				float temp_output_20_0_g10 = ( 1.0 / ( abs( temp_output_3_0_g10 ) + abs( temp_output_8_0_g10 ) ) );
-				float temp_output_7_0_g10 = ( break6_g10.y - 0.5 );
-				float2 appendResult16_g10 = (float2(( ( ( temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) + ( temp_output_7_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 ) , ( ( ( temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10 ) - ( temp_output_5_0_g10 * temp_output_8_0_g10 * temp_output_20_0_g10 ) ) + 0.5 )));
-				float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
-				float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
-				float Delay3_g8 = ( ( (_Delay_Instance + (( appendResult16_g10.x * _Pulse_Instance ) - 0.0) * (1.0 - _Delay_Instance) / (1.0 - 0.0)) % 1.0 ) * 128.0 );
-				float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8( Band3_g8 , Delay3_g8 );
-				float temp_output_96_0 = localAudioLinkLerp3_g8;
-				float amplitude36 = temp_output_96_0;
-				float3 hsvTorgb39 = HSVToRGB( float3(( hsvTorgb32.x + ( hueShift33 * amplitude36 ) ),hsvTorgb32.y,hsvTorgb32.z) );
-				
-				float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
-				float2 uv_EmissionMap = IN.ase_texcoord3.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
-				float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
-				float3 hsvTorgb40 = RGBToHSV( ( tex2D( _EmissionMap, uv_EmissionMap ) * _EmissionColor_Instance * temp_output_96_0 ).rgb );
-				float3 hsvTorgb45 = HSVToRGB( float3(( hsvTorgb40.x + ( hueShift33 * amplitude36 ) ),hsvTorgb40.y,hsvTorgb40.z) );
-				float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
-				
-				float alpha98 = tex2DNode4.a;
-				
-				o.Albedo = hsvTorgb39;
-				o.Normal = fixed3( 0, 0, 1 );
-				o.Emission = ( hsvTorgb45 * _Emission_Instance );
-				o.Alpha = alpha98;
-				float AlphaClipThreshold = _Cutoff;
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
 
-				#ifdef _ALPHATEST_ON
-					clip( o.Alpha - AlphaClipThreshold );
-				#endif
+                float2 texCoord6 = IN.ase_texcoord3.xy * float2(1, 1) + float2(0, 0);
+                float4 tex2DNode4 = tex2D(_MainTex, texCoord6);
+                float3 hsvTorgb32 = RGBToHSV((tex2DNode4 * _Color).rgb);
+                float _AudioHueShift_Instance = UNITY_ACCESS_INSTANCED_PROP(_AudioHueShift_arr, _AudioHueShift);
+                float hueShift33 = _AudioHueShift_Instance;
+                float _Band_Instance = UNITY_ACCESS_INSTANCED_PROP(_Band_arr, _Band);
+                int Band3_g8 = (int)_Band_Instance;
+                float2 texCoord50 = IN.ase_texcoord3.xy * float2(1, 1) + float2(0, 0);
+                float2 break6_g10 = texCoord50;
+                float temp_output_5_0_g10 = (break6_g10.x - 0.5);
+                float _PulseRotation_Instance = UNITY_ACCESS_INSTANCED_PROP(_PulseRotation_arr, _PulseRotation);
+                float temp_output_2_0_g10 = radians(_PulseRotation_Instance);
+                float temp_output_3_0_g10 = cos(temp_output_2_0_g10);
+                float temp_output_8_0_g10 = sin(temp_output_2_0_g10);
+                float temp_output_20_0_g10 = (1.0 / (abs(temp_output_3_0_g10) + abs(temp_output_8_0_g10)));
+                float temp_output_7_0_g10 = (break6_g10.y - 0.5);
+                float2 appendResult16_g10 = (float2(
+                    (((temp_output_5_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10) + (temp_output_7_0_g10 *
+                        temp_output_8_0_g10 * temp_output_20_0_g10)) + 0.5),
+                    (((temp_output_7_0_g10 * temp_output_3_0_g10 * temp_output_20_0_g10) - (temp_output_5_0_g10 *
+                        temp_output_8_0_g10 * temp_output_20_0_g10)) + 0.5)));
+                float _Pulse_Instance = UNITY_ACCESS_INSTANCED_PROP(_Pulse_arr, _Pulse);
+                float _Delay_Instance = UNITY_ACCESS_INSTANCED_PROP(_Delay_arr, _Delay);
+                float Delay3_g8 = (((_Delay_Instance + ((appendResult16_g10.x * _Pulse_Instance) - 0.0) * (1.0 -
+                    _Delay_Instance) / (1.0 - 0.0)) % 1.0) * 128.0);
+                float localAudioLinkLerp3_g8 = AudioLinkLerp3_g8(Band3_g8, Delay3_g8);
+                float temp_output_96_0 = localAudioLinkLerp3_g8;
+                float amplitude36 = temp_output_96_0;
+                float3 hsvTorgb39 = HSVToRGB(float3((hsvTorgb32.x + (hueShift33 * amplitude36)), hsvTorgb32.y,
+                                                    hsvTorgb32.z));
 
-				#ifdef _DEPTHOFFSET_ON
+                float4 _EmissionMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionMap_ST_arr, _EmissionMap_ST);
+                float2 uv_EmissionMap = IN.ase_texcoord3.xy * _EmissionMap_ST_Instance.xy + _EmissionMap_ST_Instance.zw;
+                float4 _EmissionColor_Instance = UNITY_ACCESS_INSTANCED_PROP(_EmissionColor_arr, _EmissionColor);
+                float3 hsvTorgb40 = RGBToHSV(
+                    (tex2D(_EmissionMap, uv_EmissionMap) * _EmissionColor_Instance * temp_output_96_0).rgb);
+                float3 hsvTorgb45 = HSVToRGB(float3((hsvTorgb40.x + (hueShift33 * amplitude36)), hsvTorgb40.y,
+                                                    hsvTorgb40.z));
+                float _Emission_Instance = UNITY_ACCESS_INSTANCED_PROP(_Emission_arr, _Emission);
+
+                float alpha98 = tex2DNode4.a;
+
+                o.Albedo = hsvTorgb39;
+                o.Normal = fixed3(0, 0, 1);
+                o.Emission = (hsvTorgb45 * _Emission_Instance);
+                o.Alpha = alpha98;
+                float AlphaClipThreshold = _Cutoff;
+
+                #ifdef _ALPHATEST_ON
+                clip(o.Alpha - AlphaClipThreshold);
+                #endif
+
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				UnityMetaInput metaIN;
-				UNITY_INITIALIZE_OUTPUT(UnityMetaInput, metaIN);
-				metaIN.Albedo = o.Albedo;
-				metaIN.Emission = o.Emission;
-				#ifdef EDITOR_VISUALIZATION
+                UnityMetaInput metaIN;
+                UNITY_INITIALIZE_OUTPUT(UnityMetaInput, metaIN);
+                metaIN.Albedo = o.Albedo;
+                metaIN.Emission = o.Emission;
+                #ifdef EDITOR_VISUALIZATION
 					metaIN.VizUV = IN.vizUV;
 					metaIN.LightCoord = IN.lightCoord;
-				#endif
-				return UnityMetaFragment(metaIN);
-			}
-			ENDCG
-		}
+                #endif
+                return UnityMetaFragment(metaIN);
+            }
+            ENDCG
+        }
 
-		
-		Pass
-		{
-			
-			Name "ShadowCaster"
-			Tags { "LightMode"="ShadowCaster" }
-			ZWrite On
-			ZTest LEqual
-			AlphaToMask Off
 
-			CGPROGRAM
-			#define _ALPHABLEND_ON 1
-			#define UNITY_STANDARD_USE_DITHER_MASK 1
-			#define ASE_NEEDS_FRAG_SHADOWCOORDS
-			#pragma multi_compile_instancing
-			#pragma multi_compile __ LOD_FADE_CROSSFADE
-			#pragma multi_compile_fog
-			#define ASE_FOG 1
-			#define _ALPHATEST_ON 1
+        Pass
+        {
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
-			#pragma multi_compile_shadowcaster
-			#ifndef UNITY_PASS_SHADOWCASTER
-				#define UNITY_PASS_SHADOWCASTER
-			#endif
-			#include "HLSLSupport.cginc"
-			#ifndef UNITY_INSTANCED_LOD_FADE
-				#define UNITY_INSTANCED_LOD_FADE
-			#endif
-			#ifndef UNITY_INSTANCED_SH
-				#define UNITY_INSTANCED_SH
-			#endif
-			#ifndef UNITY_INSTANCED_LIGHTMAPSTS
-				#define UNITY_INSTANCED_LIGHTMAPSTS
-			#endif
-			#if ( SHADER_API_D3D11 || SHADER_API_GLCORE || SHADER_API_GLES || SHADER_API_GLES3 || SHADER_API_METAL || SHADER_API_VULKAN )
-				#define CAN_SKIP_VPOS
-			#endif
-			#include "UnityShaderVariables.cginc"
-			#include "UnityCG.cginc"
-			#include "Lighting.cginc"
-			#include "UnityPBSLighting.cginc"
-			#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+            Name "ShadowCaster"
+            Tags
+            {
+                "LightMode"="ShadowCaster"
+            }
+            ZWrite On
+            ZTest LEqual
+            AlphaToMask Off
 
-			
-			struct appdata {
-				float4 vertex : POSITION;
-				float4 tangent : TANGENT;
-				float3 normal : NORMAL;
-				float4 texcoord1 : TEXCOORD1;
-				float4 texcoord2 : TEXCOORD2;
-				float4 ase_texcoord : TEXCOORD0;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-			};
+            CGPROGRAM
+            #define _ALPHABLEND_ON 1
+            #define UNITY_STANDARD_USE_DITHER_MASK 1
+            #define ASE_NEEDS_FRAG_SHADOWCOORDS
+            #pragma multi_compile_instancing
+            #pragma multi_compile __ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #define ASE_FOG 1
+            #define _ALPHATEST_ON 1
 
-			struct v2f {
-				V2F_SHADOW_CASTER;
-				float4 ase_texcoord2 : TEXCOORD2;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
-				UNITY_VERTEX_OUTPUT_STEREO
-			};
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma skip_variants FOG_LINEAR FOG_EXP FOG_EXP2
+            #pragma multi_compile_shadowcaster
+            #ifndef UNITY_PASS_SHADOWCASTER
+            #define UNITY_PASS_SHADOWCASTER
+            #endif
+            #include "HLSLSupport.cginc"
+            #ifndef UNITY_INSTANCED_LOD_FADE
+            #define UNITY_INSTANCED_LOD_FADE
+            #endif
+            #ifndef UNITY_INSTANCED_SH
+            #define UNITY_INSTANCED_SH
+            #endif
+            #ifndef UNITY_INSTANCED_LIGHTMAPSTS
+            #define UNITY_INSTANCED_LIGHTMAPSTS
+            #endif
+            #if ( SHADER_API_D3D11 || SHADER_API_GLCORE || SHADER_API_GLES || SHADER_API_GLES3 || SHADER_API_METAL || SHADER_API_VULKAN )
+            #define CAN_SKIP_VPOS
+            #endif
+            #include "UnityShaderVariables.cginc"
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "UnityPBSLighting.cginc"
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
 
-			#ifdef UNITY_STANDARD_USE_DITHER_MASK
-				sampler3D _DitherMaskLOD;
-			#endif
-			#ifdef TESSELLATION_ON
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 tangent : TANGENT;
+                float3 normal : NORMAL;
+                float4 texcoord1 : TEXCOORD1;
+                float4 texcoord2 : TEXCOORD2;
+                float4 ase_texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                V2F_SHADOW_CASTER;
+                float4 ase_texcoord2 : TEXCOORD2;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #ifdef UNITY_STANDARD_USE_DITHER_MASK
+            sampler3D _DitherMaskLOD;
+            #endif
+            #ifdef TESSELLATION_ON
 				float _TessPhongStrength;
 				float _TessValue;
 				float _TessMin;
 				float _TessMax;
 				float _TessEdgeLength;
 				float _TessMaxDisp;
-			#endif
-			uniform sampler2D _MainTex;
-			uniform float _Cutoff;
-			UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
-			UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+            #endif
+            uniform sampler2D _MainTex;
+            uniform float _Cutoff;
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
 
-	
-			
-			v2f VertexFunction (appdata v  ) {
-				UNITY_SETUP_INSTANCE_ID(v);
-				v2f o;
-				UNITY_INITIALIZE_OUTPUT(v2f,o);
-				UNITY_TRANSFER_INSTANCE_ID(v,o);
-				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
-				o.ase_texcoord2.xy = v.ase_texcoord.xy;
-				
-				//setting value to unused interpolator channels and avoid initialization warnings
-				o.ase_texcoord2.zw = 0;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+            v2f VertexFunction(appdata v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2f o;
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.ase_texcoord2.xy = v.ase_texcoord.xy;
+
+                //setting value to unused interpolator channels and avoid initialization warnings
+                o.ase_texcoord2.zw = 0;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					float3 defaultVertexValue = v.vertex.xyz;
-				#else
-					float3 defaultVertexValue = float3(0, 0, 0);
-				#endif
-				float3 vertexValue = defaultVertexValue;
-				#ifdef ASE_ABSOLUTE_VERTEX_POS
+                #else
+                float3 defaultVertexValue = float3(0, 0, 0);
+                #endif
+                float3 vertexValue = defaultVertexValue;
+                #ifdef ASE_ABSOLUTE_VERTEX_POS
 					v.vertex.xyz = vertexValue;
-				#else
-					v.vertex.xyz += vertexValue;
-				#endif
-				v.vertex.w = 1;
-				v.normal = v.normal;
-				v.tangent = v.tangent;
+                #else
+                v.vertex.xyz += vertexValue;
+                #endif
+                v.vertex.w = 1;
+                v.normal = v.normal;
+                v.tangent = v.tangent;
 
-				TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
-				return o;
-			}
+                TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
+                return o;
+            }
 
-			#if defined(TESSELLATION_ON)
+            #if defined(TESSELLATION_ON)
 			struct VertexControl
 			{
 				float4 vertex : INTERNALTESSPOS;
@@ -2112,15 +2164,15 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				float4 tf = 1;
 				float tessValue = _TessValue; float tessMin = _TessMin; float tessMax = _TessMax;
 				float edgeLength = _TessEdgeLength; float tessMaxDisp = _TessMaxDisp;
-				#if defined(ASE_FIXED_TESSELLATION)
+            #if defined(ASE_FIXED_TESSELLATION)
 				tf = FixedTess( tessValue );
-				#elif defined(ASE_DISTANCE_TESSELLATION)
+            #elif defined(ASE_DISTANCE_TESSELLATION)
 				tf = DistanceBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, tessValue, tessMin, tessMax, UNITY_MATRIX_M, _WorldSpaceCameraPos );
-				#elif defined(ASE_LENGTH_TESSELLATION)
+            #elif defined(ASE_LENGTH_TESSELLATION)
 				tf = EdgeLengthBasedTess(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams );
-				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+            #elif defined(ASE_LENGTH_CULL_TESSELLATION)
 				tf = EdgeLengthBasedTessCull(v[0].vertex, v[1].vertex, v[2].vertex, edgeLength, tessMaxDisp, UNITY_MATRIX_M, _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
-				#endif
+            #endif
 				o.edge[0] = tf.x; o.edge[1] = tf.y; o.edge[2] = tf.z; o.inside = tf.w;
 				return o;
 			}
@@ -2145,187 +2197,257 @@ Shader "AudioLink/Surface/AudioReactiveSurface_Cutout"
 				o.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
 				o.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
 				o.ase_texcoord = patch[0].ase_texcoord * bary.x + patch[1].ase_texcoord * bary.y + patch[2].ase_texcoord * bary.z;
-				#if defined(ASE_PHONG_TESSELLATION)
+            #if defined(ASE_PHONG_TESSELLATION)
 				float3 pp[3];
 				for (int i = 0; i < 3; ++i)
 					pp[i] = o.vertex.xyz - patch[i].normal * (dot(o.vertex.xyz, patch[i].normal) - dot(patch[i].vertex.xyz, patch[i].normal));
 				float phongStrength = _TessPhongStrength;
 				o.vertex.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * o.vertex.xyz;
-				#endif
+            #endif
 				UNITY_TRANSFER_INSTANCE_ID(patch[0], o);
 				return VertexFunction(o);
 			}
-			#else
-			v2f vert ( appdata v )
-			{
-				return VertexFunction( v );
-			}
-			#endif
+            #else
+            v2f vert(appdata v)
+            {
+                return VertexFunction(v);
+            }
+            #endif
 
-			fixed4 frag (v2f IN 
-				#ifdef _DEPTHOFFSET_ON
+            fixed4 frag(v2f IN
+                #ifdef _DEPTHOFFSET_ON
 				, out float outputDepth : SV_Depth
-				#endif
-				#if !defined( CAN_SKIP_VPOS )
+                #endif
+                #if !defined( CAN_SKIP_VPOS )
 				, UNITY_VPOS_TYPE vpos : VPOS
-				#endif
-				) : SV_Target 
-			{
-				UNITY_SETUP_INSTANCE_ID(IN);
+                #endif
+            ) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(IN);
 
-				#ifdef LOD_FADE_CROSSFADE
+                #ifdef LOD_FADE_CROSSFADE
 					UNITY_APPLY_DITHER_CROSSFADE(IN.pos.xy);
-				#endif
+                #endif
 
-				#if defined(_SPECULAR_SETUP)
+                #if defined(_SPECULAR_SETUP)
 					SurfaceOutputStandardSpecular o = (SurfaceOutputStandardSpecular)0;
-				#else
-					SurfaceOutputStandard o = (SurfaceOutputStandard)0;
-				#endif
+                #else
+                SurfaceOutputStandard o = (SurfaceOutputStandard)0;
+                #endif
 
-				float2 texCoord6 = IN.ase_texcoord2.xy * float2( 1,1 ) + float2( 0,0 );
-				float4 tex2DNode4 = tex2D( _MainTex, texCoord6 );
-				float alpha98 = tex2DNode4.a;
-				
-				o.Normal = fixed3( 0, 0, 1 );
-				o.Occlusion = 1;
-				o.Alpha = alpha98;
-				float AlphaClipThreshold = _Cutoff;
-				float AlphaClipThresholdShadow = 0.5;
+                float2 texCoord6 = IN.ase_texcoord2.xy * float2(1, 1) + float2(0, 0);
+                float4 tex2DNode4 = tex2D(_MainTex, texCoord6);
+                float alpha98 = tex2DNode4.a;
 
-				#ifdef _ALPHATEST_SHADOW_ON
+                o.Normal = fixed3(0, 0, 1);
+                o.Occlusion = 1;
+                o.Alpha = alpha98;
+                float AlphaClipThreshold = _Cutoff;
+                float AlphaClipThresholdShadow = 0.5;
+
+                #ifdef _ALPHATEST_SHADOW_ON
 					if (unity_LightShadowBias.z != 0.0)
 						clip(o.Alpha - AlphaClipThresholdShadow);
-					#ifdef _ALPHATEST_ON
+                #ifdef _ALPHATEST_ON
 					else
 						clip(o.Alpha - AlphaClipThreshold);
-					#endif
-				#else
-					#ifdef _ALPHATEST_ON
-						clip(o.Alpha - AlphaClipThreshold);
-					#endif
-				#endif
+                #endif
+                #else
+                #ifdef _ALPHATEST_ON
+                clip(o.Alpha - AlphaClipThreshold);
+                #endif
+                #endif
 
-				#if defined( CAN_SKIP_VPOS )
-				float2 vpos = IN.pos;
-				#endif
+                #if defined( CAN_SKIP_VPOS )
+                float2 vpos = IN.pos;
+                #endif
 
-				#ifdef UNITY_STANDARD_USE_DITHER_MASK
-					half alphaRef = tex3D(_DitherMaskLOD, float3(vpos.xy*0.25,o.Alpha*0.9375)).a;
-					clip(alphaRef - 0.01);
-				#endif
+                #ifdef UNITY_STANDARD_USE_DITHER_MASK
+                half alphaRef = tex3D(_DitherMaskLOD, float3(vpos.xy * 0.25, o.Alpha * 0.9375)).a;
+                clip(alphaRef - 0.01);
+                #endif
 
-				#ifdef _DEPTHOFFSET_ON
+                #ifdef _DEPTHOFFSET_ON
 					outputDepth = IN.pos.z;
-				#endif
+                #endif
 
-				SHADOW_CASTER_FRAGMENT(IN)
-			}
-			ENDCG
-		}
-		
-	}
-	CustomEditor "ASEMaterialInspector"
-	
-	
+                SHADOW_CASTER_FRAGMENT(IN)
+            }
+            ENDCG
+        }
+
+        // DepthOnly pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode"="DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #pragma multi_compile_instancing
+            #pragma target 3.0
+            #pragma prefer_hlslcc gles
+            #pragma exclude_renderers d3d11_9x
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            #define _ALPHATEST_ON 1
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            uniform sampler2D _MainTex;
+            uniform float _Cutoff;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.texcoord = v.texcoord;
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_TARGET
+            {
+                UNITY_SETUP_INSTANCE_ID(i);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+
+                #ifdef LOD_FADE_CROSSFADE
+            UNITY_APPLY_DITHER_CROSSFADE(i.pos.xy);
+                #endif
+
+                float4 tex = tex2D(_MainTex, i.texcoord);
+
+                #ifdef _ALPHATEST_ON
+                clip(tex.a - _Cutoff);
+                #endif
+
+                return 0;
+            }
+            ENDHLSL
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode"="DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #pragma multi_compile_instancing
+            #pragma target 3.0
+            #pragma prefer_hlslcc gles
+            #pragma exclude_renderers d3d11_9x
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            #define _ALPHATEST_ON 1
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float4 tangent : TANGENT;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                float3 normal : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            uniform sampler2D _MainTex;
+            uniform sampler2D _BumpMap;
+            uniform float _BumpScale;
+            uniform float _Cutoff;
+
+            UNITY_INSTANCING_BUFFER_START(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _BumpMap_ST)
+            UNITY_INSTANCING_BUFFER_END(AudioLinkSurfaceAudioReactiveSurface_Cutout)
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.texcoord = v.texcoord;
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_TARGET
+            {
+                UNITY_SETUP_INSTANCE_ID(i);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+
+                #ifdef LOD_FADE_CROSSFADE
+                UNITY_APPLY_DITHER_CROSSFADE(i.pos.xy);
+                #endif
+
+                float4 tex = tex2D(_MainTex, i.texcoord);
+
+                #ifdef _ALPHATEST_ON
+                clip(tex.a - _Cutoff);
+                #endif
+
+                float4 _BumpMap_ST_Instance = UNITY_ACCESS_INSTANCED_PROP(
+                    AudioLinkSurfaceAudioReactiveSurface_Cutout, _BumpMap_ST);
+                float2 uv_BumpMap = i.texcoord * _BumpMap_ST_Instance.xy + _BumpMap_ST_Instance.zw;
+
+                float3 normalTS = UnpackNormal(tex2D(_BumpMap, uv_BumpMap));
+                normalTS.xy *= _BumpScale;
+                normalTS.z = sqrt(1.0 - saturate(dot(normalTS.xy, normalTS.xy)));
+
+                float3 normalWS = normalize(normalTS);
+
+                // Encode normal and depth
+                return float4(normalWS * 0.5 + 0.5, 0);
+            }
+            ENDHLSL
+        }
+    }
 }
-/*ASEBEGIN
-Version=18908
-3114.4;81.6;2712;1462;2419.09;511.9547;1.305492;True;False
-Node;AmplifyShaderEditor.TextureCoordinatesNode;6;-1357,-367;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.SamplerNode;4;-1039,-416;Inherit;True;Property;_MainTex;Albedo;0;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;white;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.RegisterLocalVarNode;98;-616.8574,-440.1531;Inherit;False;alpha;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.HSVToRGBNode;45;252.8217,636.5342;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.RegisterLocalVarNode;36;-599.8431,921.3793;Inherit;False;amplitude;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;13;258.2,923.202;Inherit;False;Property;_Metallic;Metallic;3;0;Create;True;0;0;0;False;0;False;0;0.5;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SamplerNode;14;-989.8879,298.6613;Inherit;True;Property;_EmissionMap;Emission Map;7;0;Create;True;0;0;0;False;0;False;-1;None;None;True;0;False;gray;Auto;False;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.GetLocalVarNode;41;-311.1783,767.5342;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;17;-1434.696,642.8046;Inherit;False;InstancedProperty;_Band;Band;10;2;[Header];[IntRange];Create;True;1;Audio Section;0;0;False;0;False;0;0;0;3;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleAddOpNode;35;8.705078,-321.8591;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.GetLocalVarNode;42;-304.7005,662.272;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.BreakToComponentsNode;78;-1694.509,804.9429;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
-Node;AmplifyShaderEditor.FunctionNode;93;-1490.614,908.6327;Inherit;False;BandPulse;-1;;9;c478702160369ce4480fa2fb6d734ffa;0;3;1;FLOAT;0;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.FunctionNode;69;-1965.055,774.2052;Inherit;False;RotateUVFill;-1;;10;459952d587cbfe742a7e7f4a8a0a4169;0;2;1;FLOAT2;0,0;False;2;FLOAT;0;False;1;FLOAT2;0
-Node;AmplifyShaderEditor.RangedFloatNode;18;-1829.046,1036.233;Inherit;False;InstancedProperty;_Delay;Delay;11;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;57;-1829.967,934.3949;Inherit;False;InstancedProperty;_Pulse;Pulse;12;1;[Header];Create;True;1;Pulse Across UVs;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RadiansOpNode;51;-2161.509,869.1142;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;49;-2459.856,880.3222;Inherit;False;InstancedProperty;_PulseRotation;Pulse Rotation;14;0;Create;True;0;0;0;False;0;False;0;0;0;360;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;11;-502,92;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.RangedFloatNode;31;-1390.638,-584.899;Inherit;False;InstancedProperty;_AudioHueShift;Audio Hue Shift;13;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;101;-1214.774,934.5303;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;128;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;12;261.2,1021.201;Inherit;False;Property;_Smoothness;Smoothness;4;0;Create;True;0;0;0;False;0;False;0.5;0.5;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SamplerNode;9;-936,-2;Inherit;True;Property;_BumpMap;Normal Map;5;0;Create;False;0;0;0;False;0;False;-1;None;None;True;0;False;bump;Auto;True;Object;-1;Auto;Texture2D;8;0;SAMPLER2D;;False;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT2;0,0;False;4;FLOAT2;0,0;False;5;FLOAT;1;False;6;FLOAT;0;False;7;SAMPLERSTATE;;False;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.TextureCoordinatesNode;50;-2463.205,741.2821;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.RGBToHSVNode;40;-310.7005,431.272;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.GetLocalVarNode;34;-366.2949,-141.8591;Inherit;False;33;hueShift;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;10;-812,202;Inherit;False;Property;_BumpScale;Normal Scale;6;0;Create;False;0;0;0;False;0;False;1;1;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.GetLocalVarNode;37;-372.7727,-36.59692;Inherit;False;36;amplitude;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;43;-91.17834,730.5342;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleAddOpNode;44;70.29944,482.272;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;38;-152.7727,-73.59692;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RegisterLocalVarNode;33;-1046.295,-583.8591;Inherit;False;hueShift;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;5;-597,-280;Inherit;False;2;2;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;1;COLOR;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;15;-528.8879,636.6613;Inherit;False;3;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;0;False;1;COLOR;0
-Node;AmplifyShaderEditor.RGBToHSVNode;32;-372.2949,-372.8591;Inherit;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.RangedFloatNode;100;400.1211,1268.736;Inherit;False;Property;_Cutoff;Cutoff;1;0;Create;True;0;0;0;False;0;False;0.5;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;2;-955,-202.5;Inherit;False;Property;_Color;Color;2;0;Create;True;0;0;0;False;0;False;0.4980392,0.4980392,0.4980392,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.HSVToRGBNode;39;191.2273,-167.5969;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.RangedFloatNode;46;255.5175,800.3702;Inherit;False;InstancedProperty;_Emission;Emission Scale;9;0;Create;False;0;0;0;False;0;False;1;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;47;534.9175,735.4701;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.FunctionNode;96;-976.309,831.6292;Inherit;False;4BandAmplitudeLerp;-1;;8;3cf4b6e83381a9a4f84f8cf857bc3af5;0;2;2;INT;0;False;4;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.GetLocalVarNode;99;353.124,1122.521;Inherit;False;98;alpha;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;3;-935.8119,580.942;Inherit;False;InstancedProperty;_EmissionColor;Emission Color;8;1;[HDR];Create;True;0;0;0;False;0;False;0,0,0,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;83;895.8018,686.1933;Float;False;True;-1;2;ASEMaterialInspector;0;10;AudioLink/Surface/AudioReactiveSurface_Cutout;f0be08cf82190c945883605df227bec5;True;ForwardBase;0;1;ForwardBase;18;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;2;False;-1;True;3;False;-1;False;True;3;RenderType=Transparent=RenderType;Queue=Transparent=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;5;False;-1;10;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;40;Workflow,InvertActionOnDeselection;1;Surface;1;  Blend;0;  Refraction Model;0;  Dither Shadows;1;Two Sided;1;Deferred Pass;1;Transmission;0;  Transmission Shadow;0.5,False,-1;Translucency;0;  Translucency Strength;1,False,-1;  Normal Distortion;0.5,False,-1;  Scattering;2,False,-1;  Direct;0.9,False,-1;  Ambient;0.1,False,-1;  Shadow;0.5,False,-1;Cast Shadows;1;  Use Shadow Threshold;0;Receive Shadows;1;GPU Instancing;1;LOD CrossFade;1;Built-in Fog;1;Ambient Light;1;Meta Pass;1;Add Pass;1;Override Baked GI;0;Extra Pre Pass;0;Tessellation;0;  Phong;0;  Strength;0.5,False,-1;  Type;0;  Tess;16,False,-1;  Min;10,False,-1;  Max;25,False,-1;  Edge Length;16,False,-1;  Max Displacement;25,False,-1;Fwd Specular Highlights Toggle;0;Fwd Reflections Toggle;0;Disable Batching;0;Vertex Position,InvertActionOnDeselection;1;0;6;False;True;True;True;True;True;False;;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;85;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Deferred;0;3;Deferred;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Deferred;True;2;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;82;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ExtraPrePass;0;0;ExtraPrePass;6;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;1;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;True;True;0;False;-1;0;False;-1;True;1;LightMode=ForwardBase;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;86;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;Meta;0;4;Meta;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Meta;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;87;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ShadowCaster;0;5;ShadowCaster;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;False;-1;True;3;False;-1;False;True;1;LightMode=ShadowCaster;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode;84;824,664;Float;False;False;-1;2;ASEMaterialInspector;0;12;New Amplify Shader;f0be08cf82190c945883605df227bec5;True;ForwardAdd;0;2;ForwardAdd;0;False;True;0;1;False;-1;0;False;-1;0;1;False;-1;0;False;-1;True;0;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;True;0;False;-1;False;True;0;False;-1;False;True;True;True;True;True;0;False;-1;False;False;False;False;False;False;False;True;False;255;False;-1;255;False;-1;255;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;7;False;-1;1;False;-1;1;False;-1;1;False;-1;False;True;1;False;-1;True;3;False;-1;False;True;3;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;DisableBatching=False=DisableBatching;True;2;0;False;True;4;5;False;-1;1;False;-1;0;1;False;-1;0;False;-1;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;-1;False;False;True;1;LightMode=ForwardAdd;False;0;;0;0;Standard;0;False;0
-WireConnection;4;1;6;0
-WireConnection;98;0;4;4
-WireConnection;45;0;44;0
-WireConnection;45;1;40;2
-WireConnection;45;2;40;3
-WireConnection;36;0;96;0
-WireConnection;35;0;32;1
-WireConnection;35;1;38;0
-WireConnection;78;0;69;0
-WireConnection;93;1;78;0
-WireConnection;93;2;57;0
-WireConnection;93;3;18;0
-WireConnection;69;1;50;0
-WireConnection;69;2;51;0
-WireConnection;51;0;49;0
-WireConnection;11;0;9;0
-WireConnection;11;1;10;0
-WireConnection;101;0;93;0
-WireConnection;40;0;15;0
-WireConnection;43;0;42;0
-WireConnection;43;1;41;0
-WireConnection;44;0;40;1
-WireConnection;44;1;43;0
-WireConnection;38;0;34;0
-WireConnection;38;1;37;0
-WireConnection;33;0;31;0
-WireConnection;5;0;4;0
-WireConnection;5;1;2;0
-WireConnection;15;0;14;0
-WireConnection;15;1;3;0
-WireConnection;15;2;96;0
-WireConnection;32;0;5;0
-WireConnection;39;0;35;0
-WireConnection;39;1;32;2
-WireConnection;39;2;32;3
-WireConnection;47;0;45;0
-WireConnection;47;1;46;0
-WireConnection;96;2;17;0
-WireConnection;96;4;101;0
-WireConnection;83;0;39;0
-WireConnection;83;1;11;0
-WireConnection;83;2;47;0
-WireConnection;83;4;13;0
-WireConnection;83;5;12;0
-WireConnection;83;7;99;0
-WireConnection;83;8;100;0
-ASEEND*/
-//CHKSM=B4ACAD35915A34A62FB02B0FFB35F6EAC36F4E5A

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface_Cutout.shader.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface_Cutout.shader.meta
@@ -1,9 +1,3 @@
 fileFormatVersion: 2
-guid: bfb57ac73abf48f4b95171f3c88fd46c
-ShaderImporter:
-  externalObjects: {}
-  defaultTextures: []
-  nonModifiableTextures: []
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+guid: 079d529a219341b39c885374c0fe36eb
+timeCreated: 1747723620

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface_SmoothAlpha.shader.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioReactiveSurface_SmoothAlpha.shader.meta
@@ -1,9 +1,3 @@
 fileFormatVersion: 2
-guid: ae33cd5657d97ea4198558b6c91d0e3e
-ShaderImporter:
-  externalObjects: {}
-  defaultTextures: []
-  nonModifiableTextures: []
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+guid: 5a3d48944a964fa48cac012f756e309c
+timeCreated: 1747723400

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioTextureOverlay.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/AudioTextureOverlay.shader
@@ -47,20 +47,20 @@
             uniform float _HighlightOpacity;
             uniform float _HighlightThickness;
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
                 // Main overlay
                 int2 coord = i.uv * float2(TEXTURE_WIDTH, TEXTURE_HEIGHT);
@@ -71,7 +71,7 @@
 
                 // Highlighted area stroke lines
                 float2 textureSize = float2(TEXTURE_WIDTH, TEXTURE_HEIGHT);
-                float2 pointA = _HighlightPosition.xy / textureSize;       // x = p1x; y = p1y; z = p2x; w = p2y;
+                float2 pointA = _HighlightPosition.xy / textureSize; // x = p1x; y = p1y; z = p2x; w = p2y;
                 float2 pointB = _HighlightPosition.zw / textureSize;
                 float2 thickness = _HighlightThickness / textureSize;
                 float4 stroke = float4(saturate((thickness - abs(i.uv - pointA)) * STROKE_POWER), saturate((thickness - abs(i.uv - pointB)) * STROKE_POWER));
@@ -82,6 +82,102 @@
                 stroke *= min(mask.x, mask.y) * _HighlightOpacity;
 
                 return baseLayer + stroke;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                // Encode normal in two channels (normalized normal * 0.5 + 0.5)
+                float3 normalWS = normalize(i.normal);
+                return float4(normalWS * 0.5 + 0.5, 1);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/Color3DText.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/Color3DText.shader
@@ -76,5 +76,102 @@ Shader "GUI/Color3DText"
             }
             ENDCG
         }
+
+        // DepthOnly pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        // DepthNormals pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                return float4(normalWS * 0.5 + 0.5, 1);
+            }
+            ENDCG
+        }
     }
 }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/GlobalStringExample.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/GlobalStringExample.shader
@@ -26,15 +26,14 @@
                 UNITY_VERTEX_OUTPUT_STEREO
             };
 
-
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
@@ -43,15 +42,15 @@
             #define PIXELFONT_ROWS 4
             #define PIXELFONT_COLS 32
 
-            float4 frag (v2f i) : SV_Target
+            float4 frag(v2f i) : SV_Target
             {
                 i.uv.y = 1.0 - i.uv.y;
-                
+
                 // Pixel location on font pixel grid
                 float2 pos = i.uv * float2(PIXELFONT_COLS, PIXELFONT_ROWS);
                 uint2 pixel = (uint2)pos;
-                
-                // Fetch character from audiolink 
+
+                // Fetch character from audiolink
                 int character = AudioLinkGetGlobalStringChar(pixel.y, pixel.x);
 
                 // AA trick
@@ -61,6 +60,101 @@
                 // Render char
                 float2 charUV = float2(4, 6) - fmod(pos, 1.0) * float2(4.0, 6.0);
                 return PrintChar(character, charUV, softness, 0);
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                return float4(normalWS * 0.5 + 0.5, 1);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Shaders/ThemeColorGrid.shader
+++ b/Packages/com.llealloo.audiolink/Runtime/Shaders/ThemeColorGrid.shader
@@ -2,7 +2,7 @@
 {
     Properties
     {
-        _MainTex ("Texture", 2D) = "white" {}
+        _MainTex ("Texture", 2D) = "black" {}
     }
     SubShader
     {
@@ -35,28 +35,123 @@
             sampler2D _MainTex;
             float4 _MainTex_ST;
 
-            v2f vert (appdata v)
+            v2f vert(appdata v)
             {
                 v2f o;
 
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 frag(v2f i) : SV_Target
             {
                 uint2 themeColorLocation = (i.uv.y > .5) ?
                     ((i.uv.x < .5)? ALPASS_THEME_COLOR0 : ALPASS_THEME_COLOR1) :
                     ((i.uv.x < .5)? ALPASS_THEME_COLOR2 : ALPASS_THEME_COLOR3);
                 fixed3 themeColor = AudioLinkData(themeColorLocation).rgb;
                 fixed4 col = tex2D(_MainTex, i.uv);
-                themeColor = lerp(themeColor, col.rgb, col.a *.25);
+                themeColor = lerp(themeColor, col.rgb, col.a * .25);
                 return fixed4(themeColor, 1);
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return 0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+            Cull Back
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float3 normal : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float3 normalWS = normalize(i.normal);
+                return float4(normalWS * 0.5 + 0.5, 1);
             }
             ENDCG
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Standalone.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Standalone.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1b51bf4d05e504a4781185588bb77ae3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.llealloo.audiolink/Runtime/Standalone/AudioLinkController-Standalone.prefab
+++ b/Packages/com.llealloo.audiolink/Runtime/Standalone/AudioLinkController-Standalone.prefab
@@ -1,0 +1,6649 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &38375230538772375
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9071750360526182109}
+  - component: {fileID: 4635787687500577949}
+  - component: {fileID: 5191790282494824355}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9071750360526182109
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 38375230538772375}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7374486068071299114}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4635787687500577949
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 38375230538772375}
+  m_CullTransparentMesh: 0
+--- !u!114 &5191790282494824355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 38375230538772375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &145381946353341829
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 12653134223094131}
+  - component: {fileID: 4939280398171317555}
+  - component: {fileID: 3231830794290121277}
+  m_Layer: 0
+  m_Name: logo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &12653134223094131
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 145381946353341829}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0.7071068, w: 0}
+  m_LocalPosition: {x: 0, y: -0.007, z: 0.0254}
+  m_LocalScale: {x: 0.56, y: 0.56, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7556339993263847431}
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 180}
+--- !u!33 &4939280398171317555
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 145381946353341829}
+  m_Mesh: {fileID: -6032782397198653175, guid: 4276f8e5a6e38e4489e789cb514ad41f, type: 3}
+--- !u!23 &3231830794290121277
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 145381946353341829}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8429b93c9834c424ba855fb4288c90aa, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &277979787632449513
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7428970740069434902}
+  - component: {fileID: 5166124189419878612}
+  m_Layer: 5
+  m_Name: Slider_Threshold1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7428970740069434902
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 277979787632449513}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3021441234894219066}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 5.8, y: -0.000061035156}
+  m_SizeDelta: {x: -11.378799, y: 304.01776}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &5166124189419878612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 277979787632449513}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 7475334915066398917}
+  m_Direction: 2
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.45
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &332822017719268901
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2157633568218986936}
+  - component: {fileID: 185206459666073314}
+  - component: {fileID: 2361090626859028915}
+  - component: {fileID: 7895102968307496727}
+  m_Layer: 5
+  m_Name: Custom Color Button 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2157633568218986936
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 332822017719268901}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 4.6382747, y: 3.3581488, z: 3.358149}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 288.61, y: -234.32}
+  m_SizeDelta: {x: 37.00138, y: 31.233166}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &185206459666073314
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 332822017719268901}
+  m_CullTransparentMesh: 0
+--- !u!114 &2361090626859028915
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 332822017719268901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7895102968307496727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 332822017719268901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3482128436074061285}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: SelectCustomColor3
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: SelectCustomColor3
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: ForceThemeColorMode
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: ForceThemeColorMode
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &463244599917297928
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2572908001226659538}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2572908001226659538
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 463244599917297928}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5617440059295792658}
+  m_Father: {fileID: 3368957840957907379}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 15.74, y: 0}
+  m_SizeDelta: {x: -39.713104, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &585406704561812342
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2271121132706967826}
+  - component: {fileID: 5929684167192556329}
+  - component: {fileID: 8493269716685451590}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2271121132706967826
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585406704561812342}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2599720882467560159}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.002, y: -0.049}
+  m_SizeDelta: {x: 14.245441, y: 14.877193}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5929684167192556329
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585406704561812342}
+  m_CullTransparentMesh: 0
+--- !u!114 &8493269716685451590
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585406704561812342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &672167156385588348
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8153577758423175161}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8153577758423175161
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 672167156385588348}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4223855430668001167}
+  m_Father: {fileID: 2829590070775855773}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &786010064041493862
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6980531544434037873}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6980531544434037873
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 786010064041493862}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -9.09e-13}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7285099460062337618}
+  m_Father: {fileID: 6235483946372504037}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000015258789, y: 0}
+  m_SizeDelta: {x: -0.0000076293945, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1261347475905278476
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7809045962362632266}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7809045962362632266
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1261347475905278476}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.00000071502}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5153347792218631889}
+  m_Father: {fileID: 6223605282221678756}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0.00002670288, y: -0.09532833}
+  m_SizeDelta: {x: -0.000022888184, y: 18.728958}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1369144809831964007
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2875333754291567085}
+  - component: {fileID: 2972644911766156582}
+  - component: {fileID: 4012159079384266789}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2875333754291567085
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369144809831964007}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7089278868254517014}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 51.728, y: 72.23}
+  m_SizeDelta: {x: 103.456894, y: 144.45609}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2972644911766156582
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369144809831964007}
+  m_CullTransparentMesh: 0
+--- !u!114 &4012159079384266789
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369144809831964007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1446565289153155046
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6439699023565543719}
+  - component: {fileID: 1569647212766163442}
+  - component: {fileID: 8191693597966108190}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6439699023565543719
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1446565289153155046}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4600231151415998608}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1569647212766163442
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1446565289153155046}
+  m_CullTransparentMesh: 0
+--- !u!114 &8191693597966108190
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1446565289153155046}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1500127598329834889
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5617440059295792658}
+  - component: {fileID: 3001191159081661997}
+  - component: {fileID: 2897172121829836491}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5617440059295792658
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1500127598329834889}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2572908001226659538}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3001191159081661997
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1500127598329834889}
+  m_CullTransparentMesh: 0
+--- !u!114 &2897172121829836491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1500127598329834889}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1560974063893263977
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7374486068071299114}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7374486068071299114
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1560974063893263977}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9071750360526182109}
+  m_Father: {fileID: 2419738623435133256}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.11199951, y: 0}
+  m_SizeDelta: {x: -11.898598, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1789779082930719533
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3021441234894219066}
+  - component: {fileID: 6302788731364909780}
+  - component: {fileID: 8675136287860281852}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3021441234894219066
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1789779082930719533}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7475334915066398917}
+  m_Father: {fileID: 7428970740069434902}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0, y: -12.4}
+  m_SizeDelta: {x: 0, y: -24.869019}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6302788731364909780
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1789779082930719533}
+  m_CullTransparentMesh: 0
+--- !u!114 &8675136287860281852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1789779082930719533}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1794484806757875109
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1397767360121804572}
+  - component: {fileID: 10288184238053112}
+  m_Layer: 13
+  m_Name: AudioLinkController-Standalone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1397767360121804572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1794484806757875109}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.000009700655, z: -0, w: 1}
+  m_LocalPosition: {x: 9.743, y: 57.977936, z: 0.001}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2674177983151179704}
+  - {fileID: 1208933201969661287}
+  - {fileID: 1366397845107444168}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -0.001, z: 0}
+--- !u!114 &10288184238053112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1794484806757875109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 111447505f22b73428da6baa8bcd8bc7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioLink: {fileID: 0}
+  controllerSyncMode: 0
+  themeColorController: {fileID: 5465907815517719114}
+  audioLinkUI: {fileID: 2100000, guid: 0f19dab2300578b4d87b7662da0e74a4, type: 2}
+  gainSlider: {fileID: 1609329386292170440}
+  fadeLengthSlider: {fileID: 5068350953373795204}
+  fadeExpFalloffSlider: {fileID: 4861726604869349215}
+  x0Slider: {fileID: 2096615394430064386}
+  x1Slider: {fileID: 8747761671180071526}
+  x2Slider: {fileID: 4335938686325015673}
+  x3Slider: {fileID: 754469517654718869}
+  threshold0Slider: {fileID: 4643723808256813386}
+  threshold1Slider: {fileID: 5166124189419878612}
+  threshold2Slider: {fileID: 7928625030794889561}
+  threshold3Slider: {fileID: 4717642866912879945}
+  autoGainToggle: {fileID: 7189434614521666937}
+  powerToggle: {fileID: 8494104252408656043}
+--- !u!1 &1841833796027619499
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6455282255378348335}
+  - component: {fileID: 1823900190934877261}
+  - component: {fileID: 2142202508063399757}
+  m_Layer: 0
+  m_Name: Screen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6455282255378348335
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841833796027619499}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: -0.7071068}
+  m_LocalPosition: {x: 0.019, y: 0, z: 0}
+  m_LocalScale: {x: 0.21800001, y: 0.3398717, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1366397845107444168}
+  m_LocalEulerAnglesHint: {x: 0, y: 270, z: 0}
+--- !u!33 &1823900190934877261
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841833796027619499}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2142202508063399757
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841833796027619499}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 0f19dab2300578b4d87b7662da0e74a4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &1969811653443752880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2711259897459287594}
+  - component: {fileID: 2541347842896217261}
+  - component: {fileID: 2714417354209795418}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2711259897459287594
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1969811653443752880}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3206538944386475789}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.002, y: -0.049}
+  m_SizeDelta: {x: 14.245441, y: 14.877193}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2541347842896217261
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1969811653443752880}
+  m_CullTransparentMesh: 0
+--- !u!114 &2714417354209795418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1969811653443752880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2187947981134331086
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1208933201969661287}
+  - component: {fileID: 8899488940047542456}
+  - component: {fileID: 4440085138540596161}
+  - component: {fileID: 6842138999311532709}
+  m_Layer: 13
+  m_Name: RightHandle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1208933201969661287
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2187947981134331086}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.00000047683716, y: 0, z: 0.13500023}
+  m_LocalScale: {x: 0.029, y: 0.145, z: 0.029}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1397767360121804572}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &8899488940047542456
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2187947981134331086}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!1773428102 &4440085138540596161
+ParentConstraint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2187947981134331086}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Weight: 1
+  m_TranslationAtRest: {x: -5.7847, y: 0.75, z: 13.207}
+  m_RotationAtRest: {x: 0, y: -90.000046, z: 0}
+  m_TranslationOffsets:
+  - {x: 0, y: 0, z: 0}
+  m_RotationOffsets:
+  - {x: 0, y: 0, z: 0}
+  m_AffectTranslationX: 1
+  m_AffectTranslationY: 1
+  m_AffectTranslationZ: 1
+  m_AffectRotationX: 1
+  m_AffectRotationY: 1
+  m_AffectRotationZ: 1
+  m_Active: 1
+  m_IsLocked: 1
+  m_Sources:
+  - sourceTransform: {fileID: 6183987660420354407}
+    weight: 1
+--- !u!64 &6842138999311532709
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2187947981134331086}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2732977768007618927
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5153347792218631889}
+  - component: {fileID: 2412017241673674895}
+  - component: {fileID: 506261367439910559}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5153347792218631889
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2732977768007618927}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7809045962362632266}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 50.979034, y: 18.824}
+  m_SizeDelta: {x: 101.95974, y: 37.64892}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2412017241673674895
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2732977768007618927}
+  m_CullTransparentMesh: 0
+--- !u!114 &506261367439910559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2732977768007618927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2824589044617920902
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1986949546413978883}
+  - component: {fileID: 8936448494277439481}
+  - component: {fileID: 7308102546036912584}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1986949546413978883
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2824589044617920902}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8177582433877066291}
+  m_Father: {fileID: 7004530268245970216}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -24.46, y: -1.5800018}
+  m_SizeDelta: {x: -50.12819, y: 2.3358154}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8936448494277439481
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2824589044617920902}
+  m_CullTransparentMesh: 0
+--- !u!114 &7308102546036912584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2824589044617920902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2840523012186326810
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7475334915066398917}
+  - component: {fileID: 3931333853540122131}
+  - component: {fileID: 235832161998578967}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7475334915066398917
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2840523012186326810}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4096910275354402081}
+  m_Father: {fileID: 3021441234894219066}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3931333853540122131
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2840523012186326810}
+  m_CullTransparentMesh: 0
+--- !u!114 &235832161998578967
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2840523012186326810}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3046191364785374329
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2740456805363378744}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2740456805363378744
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3046191364785374329}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1695124955947949640}
+  m_Father: {fileID: 2419738623435133256}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0.11199951, y: -0.000012397766}
+  m_SizeDelta: {x: -11.89875, y: 22.79768}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3271133074688806270
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 695578065925340510}
+  - component: {fileID: 5465907815517719114}
+  m_Layer: 0
+  m_Name: ThemeColorController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &695578065925340510
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3271133074688806270}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1366397845107444168}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5465907815517719114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3271133074688806270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 111324e7f26747b458f38aee49327eb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  themeColor1: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  themeColor2: {r: 0, g: 0, b: 1, a: 1}
+  themeColor3: {r: 1, g: 0, b: 0, a: 1}
+  themeColor4: {r: 0, g: 1, b: 0, a: 1}
+  audioLink: {fileID: 0}
+  audioLinkUI: {fileID: 2100000, guid: 0f19dab2300578b4d87b7662da0e74a4, type: 2}
+  sliderHue: {fileID: 4152130879457354760}
+  sliderSaturation: {fileID: 5073670337005725452}
+  sliderValue: {fileID: 5347854824207991043}
+  themeColorToggle: {fileID: 8045659274732559105}
+  customColorIndex: 0
+  networkSynced: 1
+--- !u!1 &3318528254590035683
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3206538944386475789}
+  - component: {fileID: 1328475769817908668}
+  - component: {fileID: 4848233983464112309}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3206538944386475789
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3318528254590035683}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2711259897459287594}
+  m_Father: {fileID: 1323575272604075960}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 7.146, y: -7.441}
+  m_SizeDelta: {x: 14.292288, y: 14.882164}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1328475769817908668
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3318528254590035683}
+  m_CullTransparentMesh: 0
+--- !u!114 &4848233983464112309
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3318528254590035683}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3564460080266913156
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5586100087566371893}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5586100087566371893
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3564460080266913156}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4106382672584385478}
+  m_Father: {fileID: 2326518282000844352}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3690045298806106588
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2829590070775855773}
+  - component: {fileID: 7665117999000982123}
+  - component: {fileID: 7018652119701903753}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2829590070775855773
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3690045298806106588}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 0.5, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8153577758423175161}
+  m_Father: {fileID: 5519527320539493857}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -12.4}
+  m_SizeDelta: {x: 0, y: -24.869019}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7665117999000982123
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3690045298806106588}
+  m_CullTransparentMesh: 0
+--- !u!114 &7018652119701903753
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3690045298806106588}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3732601082345695098
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2674177983151179704}
+  - component: {fileID: 6528866169094701806}
+  - component: {fileID: 4259308188708864679}
+  - component: {fileID: 1978806719941910600}
+  m_Layer: 13
+  m_Name: LeftHandle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2674177983151179704
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3732601082345695098}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.00000047683716, y: 0, z: -0.13500023}
+  m_LocalScale: {x: 0.029, y: 0.145, z: 0.029}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1397767360121804572}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &6528866169094701806
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3732601082345695098}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!1773428102 &4259308188708864679
+ParentConstraint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3732601082345695098}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Weight: 1
+  m_TranslationAtRest: {x: -5.5152, y: 0.75, z: 13.207}
+  m_RotationAtRest: {x: 0, y: -90.000046, z: 0}
+  m_TranslationOffsets:
+  - {x: 0, y: 0, z: 0}
+  m_RotationOffsets:
+  - {x: 0, y: 0, z: 0}
+  m_AffectTranslationX: 1
+  m_AffectTranslationY: 1
+  m_AffectTranslationZ: 1
+  m_AffectRotationX: 1
+  m_AffectRotationY: 1
+  m_AffectRotationZ: 1
+  m_Active: 1
+  m_IsLocked: 1
+  m_Sources:
+  - sourceTransform: {fileID: 4560367808125533362}
+    weight: 1
+--- !u!64 &1978806719941910600
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3732601082345695098}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &3822635048160383592
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8764126783695272231}
+  - component: {fileID: 5524314526934554788}
+  - component: {fileID: 8636602831783035609}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8764126783695272231
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3822635048160383592}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5167460752056731977}
+  m_Father: {fileID: 6921457177285875301}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -12.399994}
+  m_SizeDelta: {x: 0, y: -24.869019}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5524314526934554788
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3822635048160383592}
+  m_CullTransparentMesh: 0
+--- !u!114 &8636602831783035609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3822635048160383592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3958539602770511144
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5624405514017617289}
+  - component: {fileID: 3861807457780579443}
+  - component: {fileID: 3342787415102289865}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5624405514017617289
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3958539602770511144}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0000047983}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7692177330846266360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 54.71, y: 24.09}
+  m_SizeDelta: {x: 109.42073, y: 48.188652}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3861807457780579443
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3958539602770511144}
+  m_CullTransparentMesh: 0
+--- !u!114 &3342787415102289865
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3958539602770511144}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4013112676918082541
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7692177330846266360}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7692177330846266360
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4013112676918082541}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5624405514017617289}
+  m_Father: {fileID: 7533516869268000041}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -0.86999893, y: 0.000002861023}
+  m_SizeDelta: {x: -12.87178, y: 22.902977}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4181616823137790625
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4223855430668001167}
+  - component: {fileID: 7337033341670864650}
+  - component: {fileID: 4078467345691487882}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4223855430668001167
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4181616823137790625}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8153577758423175161}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7337033341670864650
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4181616823137790625}
+  m_CullTransparentMesh: 0
+--- !u!114 &4078467345691487882
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4181616823137790625}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4424836453077694235
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7089278868254517014}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7089278868254517014
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4424836453077694235}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.00000071499}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2875333754291567085}
+  m_Father: {fileID: 2507377893357847466}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0.37599945, y: 0}
+  m_SizeDelta: {x: 0.7526169, y: 71.61876}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4464290890145858429
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2326518282000844352}
+  - component: {fileID: 986543382084595418}
+  - component: {fileID: 5704036931704340029}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2326518282000844352
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4464290890145858429}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5586100087566371893}
+  m_Father: {fileID: 6246588813887350014}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.099998474, y: -1.5800018}
+  m_SizeDelta: {x: -0.2111206, y: 2.3358154}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &986543382084595418
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4464290890145858429}
+  m_CullTransparentMesh: 0
+--- !u!114 &5704036931704340029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4464290890145858429}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4568096534852019573
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162116543291623283}
+  - component: {fileID: 680921963661505853}
+  - component: {fileID: 7975106978805538866}
+  - component: {fileID: 316554010001738333}
+  m_Layer: 5
+  m_Name: Reset Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &162116543291623283
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568096534852019573}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 321.61, y: -545.13}
+  m_SizeDelta: {x: 104.6315, y: 104.49519}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &680921963661505853
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568096534852019573}
+  m_CullTransparentMesh: 0
+--- !u!114 &7975106978805538866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568096534852019573}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &316554010001738333
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568096534852019573}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7975106978805538866}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: ResetSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: ResetSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &4681647118593280051
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7285099460062337618}
+  - component: {fileID: 6517330799693219065}
+  - component: {fileID: 6099430218541327099}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7285099460062337618
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4681647118593280051}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6980531544434037873}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6517330799693219065
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4681647118593280051}
+  m_CullTransparentMesh: 0
+--- !u!114 &6099430218541327099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4681647118593280051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4745533410112716584
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3380943285678105000}
+  - component: {fileID: 4717642866912879945}
+  m_Layer: 5
+  m_Name: Slider_Threshold3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3380943285678105000
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4745533410112716584}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4088976109539662184}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.75, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -16.82, y: -0.000061035156}
+  m_SizeDelta: {x: -11.33017, y: 304.01776}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &4717642866912879945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4745533410112716584}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 4600231151415998608}
+  m_Direction: 2
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.45
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &4754608457258221232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1891174179346733848}
+  - component: {fileID: 8045659274732559105}
+  m_Layer: 5
+  m_Name: Theme Color Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1891174179346733848
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4754608457258221232}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 8.565563, y: 8.236046, z: 8.565563}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1171932335667532186}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 289.46, y: -389.25}
+  m_SizeDelta: {x: 20.396492, y: 19.913795}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8045659274732559105
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4754608457258221232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2805803105956659018}
+  toggleTransition: 1
+  graphic: {fileID: 7830060302594420371}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: ToggleThemeColorMode
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: ToggleThemeColorMode
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 1
+--- !u!1 &4799285352269691676
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4503590740417712495}
+  - component: {fileID: 5276459855080071080}
+  - component: {fileID: 335923140076819651}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4503590740417712495
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4799285352269691676}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8731426031912357476}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5276459855080071080
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4799285352269691676}
+  m_CullTransparentMesh: 0
+--- !u!114 &335923140076819651
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4799285352269691676}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4829105348252402151
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4311935170012768453}
+  - component: {fileID: 7464219546299043853}
+  - component: {fileID: 6191119575393424843}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4311935170012768453
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4829105348252402151}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.7, y: 1, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4805086327160447255}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.93, y: 1.18}
+  m_SizeDelta: {x: 49.92552, y: 277.7479}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7464219546299043853
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4829105348252402151}
+  m_CullTransparentMesh: 0
+--- !u!114 &6191119575393424843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4829105348252402151}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4840166335967460489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4805086327160447255}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4805086327160447255
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4840166335967460489}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4311935170012768453}
+  m_Father: {fileID: 7843859677554645055}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4872692552209926749
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8031156299599881941}
+  - component: {fileID: 4335938686325015673}
+  m_Layer: 5
+  m_Name: Slider_X2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8031156299599881941
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4872692552209926749}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7843859677554645055}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.461, y: 0.5}
+  m_AnchorMax: {x: 0.704, y: 0.5}
+  m_AnchoredPosition: {x: -3.02, y: 455.72}
+  m_SizeDelta: {x: -11.005905, y: 278.39984}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4335938686325015673
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4872692552209926749}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 4805086327160447255}
+  m_Direction: 0
+  m_MinValue: 0.461
+  m_MaxValue: 0.628
+  m_WholeNumbers: 0
+  m_Value: 0.5
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &4895666514557740415
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7556339993263847431}
+  - component: {fileID: 618006601564848906}
+  - component: {fileID: 6331601867143812390}
+  m_Layer: 0
+  m_Name: tablet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7556339993263847431
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4895666514557740415}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.5, y: 0.5, z: 0.5, w: 0.5}
+  m_LocalPosition: {x: 0.00365, y: 0, z: 0}
+  m_LocalScale: {x: 0.944, y: 0.944, z: 0.944}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 12653134223094131}
+  m_Father: {fileID: 4227783675311283938}
+  m_LocalEulerAnglesHint: {x: -90, y: 90, z: 0}
+--- !u!33 &618006601564848906
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4895666514557740415}
+  m_Mesh: {fileID: 4999432379968118326, guid: 30551ceebefd72a45a5b8fbfd833a806, type: 3}
+--- !u!23 &6331601867143812390
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4895666514557740415}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e1a6e59d5b7a5f041acf4da9a46e2577, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &5020102558861620341
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1717441202373650720}
+  - component: {fileID: 343435593196054123}
+  - component: {fileID: 891321033076192131}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1717441202373650720
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5020102558861620341}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2916212673142533443}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &343435593196054123
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5020102558861620341}
+  m_CullTransparentMesh: 0
+--- !u!114 &891321033076192131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5020102558861620341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5087921500955316215
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4227783675311283938}
+  m_Layer: 0
+  m_Name: Geometry
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4227783675311283938
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5087921500955316215}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7556339993263847431}
+  m_Father: {fileID: 1366397845107444168}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5097168760524540383
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7004530268245970216}
+  - component: {fileID: 8747761671180071526}
+  m_Layer: 5
+  m_Name: Slider_X1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7004530268245970216
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5097168760524540383}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1986949546413978883}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.242, y: 0.5}
+  m_AnchorMax: {x: 0.461, y: 0.5}
+  m_AnchoredPosition: {x: 7.45, y: 455.72}
+  m_SizeDelta: {x: -9.918945, y: 278.39984}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8747761671180071526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5097168760524540383}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 8177582433877066291}
+  m_Direction: 0
+  m_MinValue: 0.242
+  m_MaxValue: 0.387
+  m_WholeNumbers: 0
+  m_Value: 0.25
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &5253653448660829502
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2507377893357847466}
+  - component: {fileID: 5073670337005725452}
+  m_Layer: 5
+  m_Name: Slider_Saturation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2507377893357847466
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5253653448660829502}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5543343, y: 0.50460076, z: 0.41872102}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7089278868254517014}
+  - {fileID: 2916212673142533443}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 47.88, y: -389.5101}
+  m_SizeDelta: {x: 102.6922, y: 145.69368}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5073670337005725452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5253653448660829502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 1717441202373650720}
+  m_Direction: 0
+  m_MinValue: 0.0001
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.0001
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: OnGUIchange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: OnGUIchange
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: ForceThemeColorMode
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &5284472412731938698
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4088976109539662184}
+  - component: {fileID: 51794401435567201}
+  - component: {fileID: 2137800290859930637}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4088976109539662184
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5284472412731938698}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 0.5, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4600231151415998608}
+  m_Father: {fileID: 3380943285678105000}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -12.4}
+  m_SizeDelta: {x: 0, y: -24.869019}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &51794401435567201
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5284472412731938698}
+  m_CullTransparentMesh: 0
+--- !u!114 &2137800290859930637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5284472412731938698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5424259045613290007
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2916212673142533443}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2916212673142533443
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5424259045613290007}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -9.09e-13}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1717441202373650720}
+  m_Father: {fileID: 2507377893357847466}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000022888184, y: 0}
+  m_SizeDelta: {x: -0.0000076293945, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5720835784951899450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9201664895810713798}
+  - component: {fileID: 872840443248429070}
+  - component: {fileID: 6718058902651599123}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9201664895810713798
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5720835784951899450}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5167460752056731977}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &872840443248429070
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5720835784951899450}
+  m_CullTransparentMesh: 0
+--- !u!114 &6718058902651599123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5720835784951899450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5822382278151835792
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5167460752056731977}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5167460752056731977
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5822382278151835792}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9201664895810713798}
+  m_Father: {fileID: 8764126783695272231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5900917320193733839
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3080089409404606384}
+  - component: {fileID: 5133751956154153616}
+  - component: {fileID: 1157001563215910892}
+  - component: {fileID: 2125731155135445091}
+  m_Layer: 5
+  m_Name: Custom Color Button 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3080089409404606384
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5900917320193733839}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 4.711491, y: 3.3062627, z: 3.306263}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 95.71, y: -234.73}
+  m_SizeDelta: {x: 36.305077, y: 31.639523}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5133751956154153616
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5900917320193733839}
+  m_CullTransparentMesh: 0
+--- !u!114 &1157001563215910892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5900917320193733839}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2125731155135445091
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5900917320193733839}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3482128436074061285}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: SelectCustomColor2
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: SelectCustomColor2
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: ForceThemeColorMode
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: ForceThemeColorMode
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &6015837778493024652
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4096910275354402081}
+  - component: {fileID: 5803650559646718267}
+  - component: {fileID: 4122516228469248056}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4096910275354402081
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6015837778493024652}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7475334915066398917}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5803650559646718267
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6015837778493024652}
+  m_CullTransparentMesh: 0
+--- !u!114 &4122516228469248056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6015837778493024652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6236167370568318572
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6223605282221678756}
+  - component: {fileID: 4152130879457354760}
+  m_Layer: 5
+  m_Name: Slider_Hue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6223605282221678756
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6236167370568318572}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 3.5523, y: 4.280877, z: 3.5523}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7809045962362632266}
+  - {fileID: 3276897788211072131}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -192.07007, y: -389.5}
+  m_SizeDelta: {x: 101.973495, y: 37.839172}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4152130879457354760
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6236167370568318572}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 7550570740444265499}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 0.9999
+  m_WholeNumbers: 0
+  m_Value: 0.5
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: OnGUIchange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: OnGUIchange
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: ForceThemeColorMode
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &6459723253494669400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4018641501974209114}
+  - component: {fileID: 8169648256916600346}
+  - component: {fileID: 762363689584547014}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4018641501974209114
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6459723253494669400}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8966799019769881247}
+  m_Father: {fileID: 2510631746376650091}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -24.269997, y: -1.5800018}
+  m_SizeDelta: {x: -50.14769, y: 2.3358154}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8169648256916600346
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6459723253494669400}
+  m_CullTransparentMesh: 0
+--- !u!114 &762363689584547014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6459723253494669400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6725992871808918722
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2510631746376650091}
+  - component: {fileID: 2096615394430064386}
+  m_Layer: 5
+  m_Name: Slider_X0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2510631746376650091
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6725992871808918722}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4018641501974209114}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0.242, y: 0.5}
+  m_AnchoredPosition: {x: 23.42, y: 455.72}
+  m_SizeDelta: {x: -10.960632, y: 278.39984}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &2096615394430064386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6725992871808918722}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 8966799019769881247}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 0.168
+  m_WholeNumbers: 0
+  m_Value: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &6743914287190580912
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4560367808125533362}
+  m_Layer: 13
+  m_Name: LeftHandleRef
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4560367808125533362
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6743914287190580912}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.135}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1366397845107444168}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6753918777051055935
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2905830933182511666}
+  - component: {fileID: 1006351804041881820}
+  - component: {fileID: 8265434557268111998}
+  - component: {fileID: 4308165891945634336}
+  m_Layer: 5
+  m_Name: Custom Color Button 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2905830933182511666
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6753918777051055935}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 4.7086005, y: 3.4441986, z: 2.9944346}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -288.25, y: -234.85}
+  m_SizeDelta: {x: 36.234375, y: 30.527664}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1006351804041881820
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6753918777051055935}
+  m_CullTransparentMesh: 0
+--- !u!114 &8265434557268111998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6753918777051055935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4308165891945634336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6753918777051055935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8265434557268111998}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: SelectCustomColor0
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: SelectCustomColor0
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: ForceThemeColorMode
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: ForceThemeColorMode
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &7058474622699503164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3276897788211072131}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3276897788211072131
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7058474622699503164}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -9.09e-13}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7550570740444265499}
+  m_Father: {fileID: 6223605282221678756}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000019073486, y: 0}
+  m_SizeDelta: {x: -0.0000076293945, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7089943480294311561
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6723403659995221527}
+  - component: {fileID: 8494104252408656043}
+  m_Layer: 5
+  m_Name: Power Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6723403659995221527
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7089943480294311561}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 7.245269, y: 6.966542, z: 7.245269}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2599720882467560159}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -321.1, y: -543.3}
+  m_SizeDelta: {x: 14.294041, y: 14.966366}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8494104252408656043
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7089943480294311561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3417182673781264537}
+  toggleTransition: 1
+  graphic: {fileID: 8493269716685451590}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 1
+--- !u!1 &7119684261411708319
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7843859677554645055}
+  - component: {fileID: 7449546891941653691}
+  - component: {fileID: 8956389616414717233}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7843859677554645055
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7119684261411708319}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4805086327160447255}
+  m_Father: {fileID: 8031156299599881941}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -24.66, y: -2.75}
+  m_SizeDelta: {x: -50.148544, y: 2.3358154}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &7449546891941653691
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7119684261411708319}
+  m_CullTransparentMesh: 0
+--- !u!114 &8956389616414717233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7119684261411708319}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7120701104504220277
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1366397845107444168}
+  - component: {fileID: 3404467253378349181}
+  m_Layer: 13
+  m_Name: AudioLinkControllerBody
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1366397845107444168
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7120701104504220277}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4227783675311283938}
+  - {fileID: 6455282255378348335}
+  - {fileID: 695578065925340510}
+  - {fileID: 8448199597959281009}
+  - {fileID: 4560367808125533362}
+  - {fileID: 6183987660420354407}
+  m_Father: {fileID: 1397767360121804572}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1773428102 &3404467253378349181
+ParentConstraint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7120701104504220277}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Weight: 1
+  m_TranslationAtRest: {x: -5.649744, y: 0.75, z: 13.207}
+  m_RotationAtRest: {x: 0, y: -90.000046, z: 0}
+  m_TranslationOffsets:
+  - {x: 0, y: 0, z: 0.135}
+  - {x: 0, y: 0, z: -0.135}
+  m_RotationOffsets:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 0}
+  m_AffectTranslationX: 1
+  m_AffectTranslationY: 1
+  m_AffectTranslationZ: 1
+  m_AffectRotationX: 1
+  m_AffectRotationY: 1
+  m_AffectRotationZ: 1
+  m_Active: 1
+  m_IsLocked: 1
+  m_Sources:
+  - sourceTransform: {fileID: 2674177983151179704}
+    weight: 0
+  - sourceTransform: {fileID: 1208933201969661287}
+    weight: 0
+--- !u!1 &7131300239076975125
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1171932335667532186}
+  - component: {fileID: 5895685173238675848}
+  - component: {fileID: 2805803105956659018}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1171932335667532186
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7131300239076975125}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2039242483022607703}
+  m_Father: {fileID: 1891174179346733848}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 10, y: -10}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5895685173238675848
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7131300239076975125}
+  m_CullTransparentMesh: 0
+--- !u!114 &2805803105956659018
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7131300239076975125}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7378166902549962923
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8448199597959281009}
+  - component: {fileID: 6471286293407735474}
+  - component: {fileID: 8327508112120152563}
+  - component: {fileID: 7781573542292928939}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8448199597959281009
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7378166902549962923}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: -0, w: -0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.000275, y: 0.000275, z: 0.000275}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2157633568218986936}
+  - {fileID: 3080089409404606384}
+  - {fileID: 3842922636669086766}
+  - {fileID: 2905830933182511666}
+  - {fileID: 1891174179346733848}
+  - {fileID: 3368957840957907379}
+  - {fileID: 7533516869268000041}
+  - {fileID: 2419738623435133256}
+  - {fileID: 2510631746376650091}
+  - {fileID: 7004530268245970216}
+  - {fileID: 8031156299599881941}
+  - {fileID: 6246588813887350014}
+  - {fileID: 6921457177285875301}
+  - {fileID: 7428970740069434902}
+  - {fileID: 5519527320539493857}
+  - {fileID: 3380943285678105000}
+  - {fileID: 6223605282221678756}
+  - {fileID: 2507377893357847466}
+  - {fileID: 6235483946372504037}
+  - {fileID: 1323575272604075960}
+  - {fileID: 162116543291623283}
+  - {fileID: 6723403659995221527}
+  m_Father: {fileID: 1366397845107444168}
+  m_LocalEulerAnglesHint: {x: 0, y: 270, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.0182, y: 0}
+  m_SizeDelta: {x: 791.4717, y: 1238.6624}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &6471286293407735474
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7378166902549962923}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 1
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &8327508112120152563
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7378166902549962923}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &7781573542292928939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7378166902549962923}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &7466944312774198383
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7904269424850844342}
+  - component: {fileID: 6152573362284660447}
+  - component: {fileID: 8109785650994993464}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7904269424850844342
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7466944312774198383}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.7, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8177582433877066291}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.66, y: 1.18}
+  m_SizeDelta: {x: 49.92552, y: 277.7479}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6152573362284660447
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7466944312774198383}
+  m_CullTransparentMesh: 0
+--- !u!114 &8109785650994993464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7466944312774198383}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7534075910395850171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3368957840957907379}
+  - component: {fileID: 1609329386292170440}
+  m_Layer: 5
+  m_Name: Slider_Gain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3368957840957907379
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7534075910395850171}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 3.5523, y: 4.280877, z: 3.5523}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4932733100682832982}
+  - {fileID: 2572908001226659538}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -63.69, y: 241.38}
+  m_SizeDelta: {x: 175.53186, y: 24.360199}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1609329386292170440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7534075910395850171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 5617440059295792658}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 2
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &7699636590890017013
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4106382672584385478}
+  - component: {fileID: 110295780510240608}
+  - component: {fileID: 5747022570820449465}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4106382672584385478
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7699636590890017013}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.7, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5586100087566371893}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1.2, y: 1.18}
+  m_SizeDelta: {x: 49.92552, y: 277.7479}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &110295780510240608
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7699636590890017013}
+  m_CullTransparentMesh: 0
+--- !u!114 &5747022570820449465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7699636590890017013}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7719295693754492187
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2419738623435133256}
+  - component: {fileID: 4861726604869349215}
+  m_Layer: 5
+  m_Name: Slider_FadeExpFalloff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2419738623435133256
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7719295693754492187}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2740456805363378744}
+  - {fileID: 7374486068071299114}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 191.53, y: 90.51}
+  m_SizeDelta: {x: 122.21417, y: 50.34384}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4861726604869349215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7719295693754492187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 9071750360526182109}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.75
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8037478346353556945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4828557590265350638}
+  - component: {fileID: 1199103350069200724}
+  - component: {fileID: 2113845496194387514}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4828557590265350638
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8037478346353556945}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.7, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8966799019769881247}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.38, y: 1.18}
+  m_SizeDelta: {x: 49.92552, y: 277.7479}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1199103350069200724
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8037478346353556945}
+  m_CullTransparentMesh: 0
+--- !u!114 &2113845496194387514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8037478346353556945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8120019830774490368
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6235483946372504037}
+  - component: {fileID: 5347854824207991043}
+  m_Layer: 5
+  m_Name: Slider_Value
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6235483946372504037
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8120019830774490368}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5543343, y: 0.50460076, z: 0.41872102}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4686836130997433178}
+  - {fileID: 6980531544434037873}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 144.6, y: -389.01}
+  m_SizeDelta: {x: 103.074066, y: 144.33899}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5347854824207991043
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8120019830774490368}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 7285099460062337618}
+  m_Direction: 0
+  m_MinValue: 0.0001
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.5
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: OnGUIchange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: OnGUIchange
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: ForceThemeColorMode
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8233506958555059560
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4686836130997433178}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4686836130997433178
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8233506958555059560}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.00000071501}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6260738715106557589}
+  m_Father: {fileID: 6235483946372504037}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0.0004272461}
+  m_SizeDelta: {x: -0.000022888184, y: 70.951996}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8332440712478145879
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3126503951648340897}
+  - component: {fileID: 1704776160653847237}
+  - component: {fileID: 8219611391358752594}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3126503951648340897
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8332440712478145879}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4932733100682832982}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 67.91, y: 12.19}
+  m_SizeDelta: {x: 135.81743, y: 24.372562}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1704776160653847237
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8332440712478145879}
+  m_CullTransparentMesh: 0
+--- !u!114 &8219611391358752594
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8332440712478145879}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8344890425715981562
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7550570740444265499}
+  - component: {fileID: 8676951899334977052}
+  - component: {fileID: 957707636317458451}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7550570740444265499
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8344890425715981562}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3276897788211072131}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8676951899334977052
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8344890425715981562}
+  m_CullTransparentMesh: 0
+--- !u!114 &957707636317458451
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8344890425715981562}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8400138400863654370
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6183987660420354407}
+  m_Layer: 13
+  m_Name: RightHandleRef
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6183987660420354407
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8400138400863654370}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.135}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1366397845107444168}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8460327006632424497
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4932733100682832982}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4932733100682832982
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8460327006632424497}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3126503951648340897}
+  m_Father: {fileID: 3368957840957907379}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 15.739998, y: 0.09000015}
+  m_SizeDelta: {x: -39.71219, y: 12.209755}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8516950970163171887
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2599720882467560159}
+  - component: {fileID: 449413601791194696}
+  - component: {fileID: 3417182673781264537}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2599720882467560159
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8516950970163171887}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2271121132706967826}
+  m_Father: {fileID: 6723403659995221527}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 7.146, y: -7.441}
+  m_SizeDelta: {x: 14.292288, y: 14.882164}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &449413601791194696
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8516950970163171887}
+  m_CullTransparentMesh: 0
+--- !u!114 &3417182673781264537
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8516950970163171887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8525292369193493551
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3842922636669086766}
+  - component: {fileID: 635225429597936128}
+  - component: {fileID: 3482128436074061285}
+  - component: {fileID: 5756553085522773}
+  m_Layer: 5
+  m_Name: Custom Color Button 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3842922636669086766
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525292369193493551}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 4.695242, y: 3.3382452, z: 3.3382454}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -96.07, y: -234.87}
+  m_SizeDelta: {x: 36.211113, y: 31.51529}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &635225429597936128
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525292369193493551}
+  m_CullTransparentMesh: 0
+--- !u!114 &3482128436074061285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525292369193493551}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5756553085522773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525292369193493551}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3482128436074061285}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: SelectCustomColor1
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: SelectCustomColor1
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5465907815517719114}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorController, AudioLink
+        m_MethodName: ForceThemeColorMode
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: ForceThemeColorMode
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8580943665391982996
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5519527320539493857}
+  - component: {fileID: 7928625030794889561}
+  m_Layer: 5
+  m_Name: Slider_Threshold2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5519527320539493857
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8580943665391982996}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2829590070775855773}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: -5.54, y: -0.000061035156}
+  m_SizeDelta: {x: -11.33017, y: 304.01776}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &7928625030794889561
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8580943665391982996}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 8153577758423175161}
+  m_Direction: 2
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.45
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8597811799467425203
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8177582433877066291}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8177582433877066291
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8597811799467425203}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7904269424850844342}
+  m_Father: {fileID: 1986949546413978883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8720011498900406220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4600231151415998608}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4600231151415998608
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8720011498900406220}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6439699023565543719}
+  m_Father: {fileID: 4088976109539662184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8762844311707508406
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8966799019769881247}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8966799019769881247
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8762844311707508406}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4828557590265350638}
+  m_Father: {fileID: 4018641501974209114}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8893346439944948463
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6246588813887350014}
+  - component: {fileID: 754469517654718869}
+  m_Layer: 5
+  m_Name: Slider_X3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6246588813887350014
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8893346439944948463}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2326518282000844352}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.704, y: 0.5}
+  m_AnchorMax: {x: 0.953, y: 0.5}
+  m_AnchoredPosition: {x: -14.17, y: 455.72}
+  m_SizeDelta: {x: -11.277695, y: 278.39984}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &754469517654718869
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8893346439944948463}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 5586100087566371893}
+  m_Direction: 0
+  m_MinValue: 0.704
+  m_MaxValue: 0.953
+  m_WholeNumbers: 0
+  m_Value: 0.75
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8990768044454430735
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2039242483022607703}
+  - component: {fileID: 3681759147484674476}
+  - component: {fileID: 7830060302594420371}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2039242483022607703
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8990768044454430735}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1171932335667532186}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3681759147484674476
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8990768044454430735}
+  m_CullTransparentMesh: 0
+--- !u!114 &7830060302594420371
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8990768044454430735}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &9002009382700687350
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6260738715106557589}
+  - component: {fileID: 6482240426287684533}
+  - component: {fileID: 560936373955255378}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6260738715106557589
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9002009382700687350}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.00001011}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4686836130997433178}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 51.921, y: 70.952}
+  m_SizeDelta: {x: 103.84232, y: 141.90503}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6482240426287684533
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9002009382700687350}
+  m_CullTransparentMesh: 0
+--- !u!114 &560936373955255378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9002009382700687350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &9012741428566264450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7533516869268000041}
+  - component: {fileID: 5068350953373795204}
+  m_Layer: 5
+  m_Name: Slider_FadeLength
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7533516869268000041
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9012741428566264450}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7692177330846266360}
+  - {fileID: 8731426031912357476}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -189.7, y: 90.15}
+  m_SizeDelta: {x: 122.16202, y: 50.57631}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5068350953373795204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9012741428566264450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 4503590740417712495}
+  m_Direction: 1
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.25
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &9103667183495392366
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1695124955947949640}
+  - component: {fileID: 6555239181080647840}
+  - component: {fileID: 8318718404661266792}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1695124955947949640
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9103667183495392366}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2740456805363378744}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 55.21, y: 24.04}
+  m_SizeDelta: {x: 110.430664, y: 48.082466}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6555239181080647840
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9103667183495392366}
+  m_CullTransparentMesh: 0
+--- !u!114 &8318718404661266792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9103667183495392366}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &9120986998586946404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6921457177285875301}
+  - component: {fileID: 4643723808256813386}
+  m_Layer: 5
+  m_Name: Slider_Threshold0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6921457177285875301
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9120986998586946404}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8764126783695272231}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0.25, y: 1}
+  m_AnchoredPosition: {x: 17.11, y: -0.000061035156}
+  m_SizeDelta: {x: -11.33017, y: 304.01776}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &4643723808256813386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9120986998586946404}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 5167460752056731977}
+  m_Direction: 2
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.45
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &9144348737219719089
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8731426031912357476}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8731426031912357476
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9144348737219719089}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4503590740417712495}
+  m_Father: {fileID: 7533516869268000041}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.86999893, y: 0}
+  m_SizeDelta: {x: -12.871796, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &9216402457766716605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1323575272604075960}
+  - component: {fileID: 7189434614521666937}
+  m_Layer: 5
+  m_Name: Auto Gain Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1323575272604075960
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9216402457766716605}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 7.245269, y: 6.966542, z: 7.245269}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3206538944386475789}
+  m_Father: {fileID: 8448199597959281009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 321.67, y: 241.13}
+  m_SizeDelta: {x: 14.294041, y: 14.966366}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7189434614521666937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9216402457766716605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4848233983464112309}
+  toggleTransition: 1
+  graphic: {fileID: 2714417354209795418}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 10288184238053112}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkController, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 1

--- a/Packages/com.llealloo.audiolink/Runtime/Standalone/AudioLinkController-Standalone.prefab.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Standalone/AudioLinkController-Standalone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d62cf0a58ab8396488bcb184053182b6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.llealloo.audiolink/Runtime/Standalone/AudioLinkControllerV0-Standalone.prefab
+++ b/Packages/com.llealloo.audiolink/Runtime/Standalone/AudioLinkControllerV0-Standalone.prefab
@@ -1,0 +1,11170 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &112518938525654429
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6348151081563346051}
+  - component: {fileID: 2959029879021279989}
+  - component: {fileID: 4833169924152702685}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6348151081563346051
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 112518938525654429}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6894109339269569084}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2959029879021279989
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 112518938525654429}
+  m_CullTransparentMesh: 0
+--- !u!114 &4833169924152702685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 112518938525654429}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7411765, g: 0.77081144, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 466899909232642061, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &245862449730036589
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5953323501105947112}
+  - component: {fileID: 7787482720040856546}
+  - component: {fileID: 511462126513589746}
+  - component: {fileID: 7462901002641241024}
+  m_Layer: 5
+  m_Name: Template
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5953323501105947112
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245862449730036589}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 495592281116711394}
+  - {fileID: 6777569332825272718}
+  m_Father: {fileID: 564383905692579421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 2}
+  m_SizeDelta: {x: 0, y: 150}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &7787482720040856546
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245862449730036589}
+  m_CullTransparentMesh: 0
+--- !u!114 &511462126513589746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245862449730036589}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.16037738, g: 0.16037738, b: 0.16037738, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7462901002641241024
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245862449730036589}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 6695695180628387938}
+  m_Horizontal: 0
+  m_Vertical: 1
+  m_MovementType: 2
+  m_Elasticity: 0.1
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 1
+  m_Viewport: {fileID: 495592281116711394}
+  m_HorizontalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 2418080210105589431}
+  m_HorizontalScrollbarVisibility: 0
+  m_VerticalScrollbarVisibility: 2
+  m_HorizontalScrollbarSpacing: 0
+  m_VerticalScrollbarSpacing: -3
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &356817424940474536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5048483632568495299}
+  - component: {fileID: 4370756793343431032}
+  - component: {fileID: 5396404201323328748}
+  m_Layer: 13
+  m_Name: TopCap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5048483632568495299
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 356817424940474536}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.016, y: 0.15, z: 0}
+  m_LocalScale: {x: 0.068, y: 0.02, z: 0.032}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2343012201522968185}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4370756793343431032
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 356817424940474536}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5396404201323328748
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 356817424940474536}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9d42585cf36563f44bb23a67ab21c519, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &362918269886741457
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5782097804942190625}
+  - component: {fileID: 6314710452990588197}
+  m_Layer: 0
+  m_Name: AudioLinkControllerV0-Standalone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5782097804942190625
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 362918269886741457}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.70710576, z: -0, w: 0.70710784}
+  m_LocalPosition: {x: 9.747, y: 57.979385, z: -0.599}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1484319440833812737}
+  - {fileID: 8856027461238760108}
+  - {fileID: 2343012201522968185}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
+--- !u!114 &6314710452990588197
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 362918269886741457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58e447505f22b73428da6baa8bcd8bc7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioLink: {fileID: 0}
+  themeColorController: {fileID: 1850939700543825432}
+  audioSpectrumDisplay: {fileID: 2100000, guid: 06e7d5350bc8fa842b4bdea5200a3a2f, type: 2}
+  gainLabel: {fileID: 5493508377970203589}
+  gainSlider: {fileID: 6009933594196146229}
+  trebleLabel: {fileID: 7250219814411528253}
+  trebleSlider: {fileID: 5909388977654816028}
+  bassLabel: {fileID: 1886681580547739433}
+  bassSlider: {fileID: 6582587184179245700}
+  fadeLengthLabel: {fileID: 9048763390749061147}
+  fadeLengthSlider: {fileID: 6553857647686057892}
+  fadeExpFalloffLabel: {fileID: 6308825743710478370}
+  fadeExpFalloffSlider: {fileID: 3511889801236120189}
+  x0Slider: {fileID: 2266064103654870701}
+  x1Slider: {fileID: 7778827356106990804}
+  x2Slider: {fileID: 6168371980679469750}
+  x3Slider: {fileID: 7394978134946401700}
+  threshold0Slider: {fileID: 8984197426162281115}
+  threshold1Slider: {fileID: 8732576365359434346}
+  threshold2Slider: {fileID: 1217531418047678844}
+  threshold3Slider: {fileID: 5123273602156987690}
+--- !u!1 &404087416551568758
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8234031431788457986}
+  - component: {fileID: 8700609270582474028}
+  - component: {fileID: 9054500918927054283}
+  - component: {fileID: 7320671726450370860}
+  m_Layer: 5
+  m_Name: Custom Color Button 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8234031431788457986
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 404087416551568758}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3938557938234977248}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 134.86, y: 32.76}
+  m_SizeDelta: {x: 36, y: 36}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8700609270582474028
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 404087416551568758}
+  m_CullTransparentMesh: 0
+--- !u!114 &9054500918927054283
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 404087416551568758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7320671726450370860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 404087416551568758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 9054500918927054283}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1850939700543825432}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorControllerV0, AudioLink
+        m_MethodName: SelectCustomColor1
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: SelectCustomColor1
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &425810339329354992
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3626197743113610512}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3626197743113610512
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425810339329354992}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6665365187150620791}
+  m_Father: {fileID: 7048797104976552735}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &448967322179792891
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7042605565267472885}
+  - component: {fileID: 2052098749795174323}
+  - component: {fileID: 4813235569290262218}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7042605565267472885
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 448967322179792891}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 621664006397135782}
+  m_Father: {fileID: 1634500531030701399}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -15}
+  m_SizeDelta: {x: 0, y: -30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2052098749795174323
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 448967322179792891}
+  m_CullTransparentMesh: 0
+--- !u!114 &4813235569290262218
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 448967322179792891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &470901354390737511
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4420782668653246763}
+  - component: {fileID: 8312615325478983038}
+  - component: {fileID: 6790720385885935675}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4420782668653246763
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470901354390737511}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 45675564460246822}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8312615325478983038
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470901354390737511}
+  m_CullTransparentMesh: 0
+--- !u!114 &6790720385885935675
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470901354390737511}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &538506734151328963
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2707185987352724042}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2707185987352724042
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 538506734151328963}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8747447408919666982}
+  - {fileID: 1385507795333360364}
+  m_Father: {fileID: 3772510671314417429}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &564682631330733437
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6325235192822953274}
+  - component: {fileID: 278339727500873586}
+  - component: {fileID: 163041159584330565}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6325235192822953274
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 564682631330733437}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 70514554250852176}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &278339727500873586
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 564682631330733437}
+  m_CullTransparentMesh: 0
+--- !u!114 &163041159584330565
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 564682631330733437}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &599449902822983232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7254425578172705206}
+  - component: {fileID: 3588654253866036344}
+  - component: {fileID: 4927871276372472242}
+  m_Layer: 5
+  m_Name: Arrows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7254425578172705206
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 599449902822983232}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 621664006397135782}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3588654253866036344
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 599449902822983232}
+  m_CullTransparentMesh: 0
+--- !u!114 &4927871276372472242
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 599449902822983232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9622642, g: 0.9622642, b: 0.9622642, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 4732271440486325600, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &664083359863967610
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8856027461238760108}
+  - component: {fileID: 4025051807939631509}
+  - component: {fileID: 7138791296790164176}
+  m_Layer: 13
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8856027461238760108
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 664083359863967610}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8547719403071840499}
+  m_Father: {fileID: 5782097804942190625}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &4025051807939631509
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 664083359863967610}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!136 &7138791296790164176
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 664083359863967610}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.015
+  m_Height: 0.32
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &684661696625690094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 70514554250852176}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &70514554250852176
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684661696625690094}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6325235192822953274}
+  m_Father: {fileID: 8389301493180030887}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &716591552676121278
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6204884200885960896}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6204884200885960896
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 716591552676121278}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8813662891045527545}
+  m_Father: {fileID: 81144368267000887}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &730528934212299797
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5020417505614498957}
+  - component: {fileID: 3322563205248873139}
+  - component: {fileID: 969945569526136604}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5020417505614498957
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 730528934212299797}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3540000653128285123}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3322563205248873139
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 730528934212299797}
+  m_CullTransparentMesh: 0
+--- !u!114 &969945569526136604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 730528934212299797}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -8932229983578582238, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &734808306417349725
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 740074316738694871}
+  - component: {fileID: 1889170461158129729}
+  - component: {fileID: 5851789827654182943}
+  m_Layer: 5
+  m_Name: selection lasso 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &740074316738694871
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 734808306417349725}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3.3394475, y: 3.3394475, z: 3.3394475}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2289852777965071185}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 456.8, y: 498.40012}
+  m_SizeDelta: {x: 128, y: 128}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &1889170461158129729
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 734808306417349725}
+  m_CullTransparentMesh: 0
+--- !u!114 &5851789827654182943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 734808306417349725}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5da651327a17f2445ac37517e67e1197, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 0.324
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &754605477027222084
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6062929864818815073}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6062929864818815073
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 754605477027222084}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1879210465794687533}
+  m_Father: {fileID: 81144368267000887}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &811942844195788164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5802662301798343228}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5802662301798343228
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 811942844195788164}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5499096108740362546}
+  - {fileID: 5092489562077111716}
+  m_Father: {fileID: 7687432004666858861}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &816746458908053301
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3772510671314417429}
+  - component: {fileID: 7870002787078052642}
+  - component: {fileID: 1735965481127614240}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3772510671314417429
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 816746458908053301}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2707185987352724042}
+  m_Father: {fileID: 8507857730353569049}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -15}
+  m_SizeDelta: {x: 0, y: -30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7870002787078052642
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 816746458908053301}
+  m_CullTransparentMesh: 0
+--- !u!114 &1735965481127614240
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 816746458908053301}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &896190095257951896
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7687428404237491344}
+  - component: {fileID: 1553520483935767697}
+  - component: {fileID: 2823683835280610133}
+  m_Layer: 5
+  m_Name: Item Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7687428404237491344
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 896190095257951896}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 67298253512936032}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 10, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1553520483935767697
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 896190095257951896}
+  m_CullTransparentMesh: 0
+--- !u!114 &2823683835280610133
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 896190095257951896}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7924528, g: 0.7924528, b: 0.7924528, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: d858746bb7f8af3458153aca58b105fc, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &941136734200991855
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6695695180628387938}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6695695180628387938
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 941136734200991855}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 67298253512936032}
+  m_Father: {fileID: 495592281116711394}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.00007247925}
+  m_SizeDelta: {x: 0, y: 28}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!1 &980411347771220783
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5499096108740362546}
+  - component: {fileID: 6199991929645529402}
+  - component: {fileID: 7593083694697904940}
+  m_Layer: 5
+  m_Name: Arrows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5499096108740362546
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 980411347771220783}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5802662301798343228}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6199991929645529402
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 980411347771220783}
+  m_CullTransparentMesh: 0
+--- !u!114 &7593083694697904940
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 980411347771220783}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9622642, g: 0.9622642, b: 0.9622642, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 4732271440486325600, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &985817497738709286
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2612446877138220124}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2612446877138220124
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 985817497738709286}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1805294052662604297}
+  m_Father: {fileID: 3540000653128285123}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1071881763412344066
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5381398319594870914}
+  - component: {fileID: 868640944161945016}
+  - component: {fileID: 2070341086187609378}
+  m_Layer: 13
+  m_Name: Plane_UdonAudioLink
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5381398319594870914
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071881763412344066}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0.15, y: 0, z: 0.0205}
+  m_LocalScale: {x: 0.0125, y: 0.0125, z: 0.0125}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2343012201522968185}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &868640944161945016
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071881763412344066}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2070341086187609378
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071881763412344066}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 1a72c7fef45e1664abd38e7079ec252d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &1147832881080192530
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6894109339269569084}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6894109339269569084
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147832881080192530}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6348151081563346051}
+  m_Father: {fileID: 4191061569453193425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1163479547072579324
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7048797104976552735}
+  - component: {fileID: 6009933594196146229}
+  m_Layer: 5
+  m_Name: Slider_Gain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7048797104976552735
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1163479547072579324}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1272647278093530404}
+  - {fileID: 3626197743113610512}
+  - {fileID: 7610088783915916655}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -100, y: 265}
+  m_SizeDelta: {x: 155, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6009933594196146229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1163479547072579324}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8078320614143970234}
+  m_FillRect: {fileID: 6665365187150620791}
+  m_HandleRect: {fileID: 8954637390730935489}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 2
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &1196888222027646389
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3989778097179809992}
+  - component: {fileID: 1621182193100739786}
+  - component: {fileID: 4339376452833791923}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3989778097179809992
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1196888222027646389}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.33333337, y: 0.33333337, z: 0.33333337}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5985062561758315514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 33.466686, y: -21.53318}
+  m_SizeDelta: {x: 620, y: 152.37558}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1621182193100739786
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1196888222027646389}
+  m_CullTransparentMesh: 0
+--- !u!114 &4339376452833791923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1196888222027646389}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1509434, g: 0.1509434, b: 0.1509434, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -8932229983578582238, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1207845867967012439
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7822150350519116539}
+  - component: {fileID: 6314609819975227113}
+  - component: {fileID: 5493508377970203589}
+  m_Layer: 5
+  m_Name: Text_Gain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7822150350519116539
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1207845867967012439}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.01}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 320}
+  m_SizeDelta: {x: 660, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6314609819975227113
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1207845867967012439}
+  m_CullTransparentMesh: 0
+--- !u!114 &5493508377970203589
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1207845867967012439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Gain:'
+--- !u!1 &1259518893172132169
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6863291016076773184}
+  - component: {fileID: 2266064103654870701}
+  m_Layer: 5
+  m_Name: Slider_X0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6863291016076773184
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259518893172132169}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3636436981537861998}
+  - {fileID: 3002984106441236886}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0.242, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 385}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &2266064103654870701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259518893172132169}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 6587541388514291736}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 0.168
+  m_WholeNumbers: 0
+  m_Value: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &1263007392794021312
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8410462824285581589}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8410462824285581589
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1263007392794021312}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7535120143339399366}
+  m_Father: {fileID: 3540000653128285123}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1297044827548290888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5164404523412461380}
+  - component: {fileID: 6107606604604340807}
+  - component: {fileID: 8448813290058636983}
+  m_Layer: 13
+  m_Name: AudioLinkPreview
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5164404523412461380
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1297044827548290888}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0000014081597, y: 0.7071068, z: -0.7071068, w: 0.0000014081597}
+  m_LocalPosition: {x: 0.0001, y: -0.0763, z: 0}
+  m_LocalScale: {x: 0.018, y: 0.01, z: 0.0045}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4131549791695146592}
+  m_LocalEulerAnglesHint: {x: -270, y: 0, z: 179.99998}
+--- !u!33 &6107606604604340807
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1297044827548290888}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8448813290058636983
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1297044827548290888}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 669f24c4250dc1e479b23e90f14b1190, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &1459554771895692224
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7323276574581615606}
+  - component: {fileID: 2068543248284714722}
+  - component: {fileID: 381330681511655096}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7323276574581615606
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1459554771895692224}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 613075870674757949}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2068543248284714722
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1459554771895692224}
+  m_CullTransparentMesh: 0
+--- !u!114 &381330681511655096
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1459554771895692224}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1461337978231121372
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9022285605094714172}
+  - component: {fileID: 44199972683738222}
+  - component: {fileID: 5135973289309484065}
+  m_Layer: 5
+  m_Name: Text_HitFade
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9022285605094714172
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461337978231121372}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.01}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.40006638, y: -45}
+  m_SizeDelta: {x: 660, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &44199972683738222
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461337978231121372}
+  m_CullTransparentMesh: 0
+--- !u!114 &5135973289309484065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461337978231121372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Hit Fade
+--- !u!1 &1465958325396266768
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4636070439337054090}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4636070439337054090
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465958325396266768}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1772169438577012145}
+  m_Father: {fileID: 3966533101865922583}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1475228934317944489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1515052127383152186}
+  - component: {fileID: 2377240240244905655}
+  - component: {fileID: 6987058725917708406}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1515052127383152186
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1475228934317944489}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8389301493180030887}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2377240240244905655
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1475228934317944489}
+  m_CullTransparentMesh: 0
+--- !u!114 &6987058725917708406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1475228934317944489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -8932229983578582238, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1475277280364669739
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3540000653128285123}
+  - component: {fileID: 5160838865076395569}
+  m_Layer: 5
+  m_Name: Slider_ThemeValue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3540000653128285123
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1475277280364669739}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5020417505614498957}
+  - {fileID: 2612446877138220124}
+  - {fileID: 8410462824285581589}
+  m_Father: {fileID: 5985062561758315514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -45.1}
+  m_SizeDelta: {x: 155, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5160838865076395569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1475277280364669739}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7304242593910984965}
+  m_FillRect: {fileID: 1805294052662604297}
+  m_HandleRect: {fileID: 7535120143339399366}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.75
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1850939700543825432}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorControllerV0, AudioLink
+        m_MethodName: OnGUIchange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: OnGUIchange
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &1486538319582318162
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5291137704904722980}
+  - component: {fileID: 7191166389357818574}
+  - component: {fileID: 2882513744523871604}
+  m_Layer: 5
+  m_Name: Text_ThemeHue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5291137704904722980
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486538319582318162}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0033322333}
+  m_LocalScale: {x: 0.33333328, y: 0.33333328, z: 0.33333328}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5985062561758315514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 113.33333, y: 0.666626}
+  m_SizeDelta: {x: 180, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7191166389357818574
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486538319582318162}
+  m_CullTransparentMesh: 0
+--- !u!114 &2882513744523871604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486538319582318162}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Hue
+
+'
+--- !u!1 &1524990577460260067
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1805294052662604297}
+  - component: {fileID: 2247462517758984561}
+  - component: {fileID: 7887392293900391965}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1805294052662604297
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1524990577460260067}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2612446877138220124}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2247462517758984561
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1524990577460260067}
+  m_CullTransparentMesh: 0
+--- !u!114 &7887392293900391965
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1524990577460260067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7411765, g: 0.77081144, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 466899909232642061, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1608039437646149956
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3736991720856878419}
+  - component: {fileID: 2541347827146907351}
+  - component: {fileID: 571982627375458275}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3736991720856878419
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1608039437646149956}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2810420970227791832}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2541347827146907351
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1608039437646149956}
+  m_CullTransparentMesh: 0
+--- !u!114 &571982627375458275
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1608039437646149956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1690968417068026513
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 45675564460246822}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &45675564460246822
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1690968417068026513}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3353378655135826526}
+  - {fileID: 4420782668653246763}
+  m_Father: {fileID: 5620743313176364246}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1709444874038270991
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1879210465794687533}
+  - component: {fileID: 1250929239768391172}
+  - component: {fileID: 4033237316424823232}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1879210465794687533
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1709444874038270991}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6062929864818815073}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.75, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1250929239768391172
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1709444874038270991}
+  m_CullTransparentMesh: 0
+--- !u!114 &4033237316424823232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1709444874038270991}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1725120299953690884
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3587909936672466149}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3587909936672466149
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725120299953690884}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4217977457897167966}
+  m_Father: {fileID: 6481320243168476059}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1799575320789845147
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6587541388514291736}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6587541388514291736
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1799575320789845147}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1600304112735116786}
+  - {fileID: 2819072468132020409}
+  m_Father: {fileID: 3002984106441236886}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1866415354977451552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 846863225823449409}
+  - component: {fileID: 6589550095638925142}
+  - component: {fileID: 2752200252225326162}
+  - component: {fileID: 9032328972253310490}
+  m_Layer: 5
+  m_Name: Custom Color Button 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &846863225823449409
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1866415354977451552}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3938557938234977248}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 134.86, y: -3.8001356}
+  m_SizeDelta: {x: 36, y: 36}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6589550095638925142
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1866415354977451552}
+  m_CullTransparentMesh: 0
+--- !u!114 &2752200252225326162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1866415354977451552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &9032328972253310490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1866415354977451552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 9054500918927054283}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1850939700543825432}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorControllerV0, AudioLink
+        m_MethodName: SelectCustomColor3
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: SelectCustomColor3
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &2015951271584421142
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4964470217518058889}
+  - component: {fileID: 7985623440069147420}
+  - component: {fileID: 7632267781330029677}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4964470217518058889
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2015951271584421142}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8944728106324634797}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &7985623440069147420
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2015951271584421142}
+  m_CullTransparentMesh: 0
+--- !u!114 &7632267781330029677
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2015951271584421142}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.06666667, g: 0.10196079, b: 0.21960786, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2160201672354240754
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6329570556181070466}
+  - component: {fileID: 7808653097180875631}
+  - component: {fileID: 4699093125148747578}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6329570556181070466
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2160201672354240754}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1441439271432301104}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7808653097180875631
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2160201672354240754}
+  m_CullTransparentMesh: 0
+--- !u!114 &4699093125148747578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2160201672354240754}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3490566, g: 0.3490566, b: 0.3490566, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2200306872429248109
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8513434883236684275}
+  - component: {fileID: 5123273602156987690}
+  m_Layer: 5
+  m_Name: Slider_Threshold3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8513434883236684275
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2200306872429248109}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5366349926897015779}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.75, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 190}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &5123273602156987690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2200306872429248109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 3377691481059036561}
+  m_Direction: 2
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.45
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &2299214180834196082
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2523277767201664368}
+  - component: {fileID: 8907788011127053611}
+  - component: {fileID: 3020976043285792852}
+  m_Layer: 5
+  m_Name: Text_ThemeColors
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2523277767201664368
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2299214180834196082}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0099967}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -330, y: -434.3}
+  m_SizeDelta: {x: 216.6, y: 40}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &8907788011127053611
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2299214180834196082}
+  m_CullTransparentMesh: 0
+--- !u!114 &3020976043285792852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2299214180834196082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Theme Colors
+--- !u!1 &2351996647766263823
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 81144368267000887}
+  - component: {fileID: 4705280400534224718}
+  m_Layer: 5
+  m_Name: Slider_ThemeSaturation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &81144368267000887
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2351996647766263823}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9075970846054324954}
+  - {fileID: 6204884200885960896}
+  - {fileID: 6062929864818815073}
+  m_Father: {fileID: 5985062561758315514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -22.3}
+  m_SizeDelta: {x: 155, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4705280400534224718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2351996647766263823}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4033237316424823232}
+  m_FillRect: {fileID: 8813662891045527545}
+  m_HandleRect: {fileID: 1879210465794687533}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.75
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1850939700543825432}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorControllerV0, AudioLink
+        m_MethodName: OnGUIchange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: OnGUIchange
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &2474742385343675158
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 564383905692579421}
+  - component: {fileID: 7319047644643665697}
+  - component: {fileID: 2746714535140008657}
+  - component: {fileID: 5823267679303912973}
+  m_Layer: 5
+  m_Name: ThemeColorDropdown
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &564383905692579421
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2474742385343675158}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3526953655024287132}
+  - {fileID: 8376191888004989568}
+  - {fileID: 5953323501105947112}
+  m_Father: {fileID: 3938557938234977248}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -7.6, y: -0.38305664}
+  m_SizeDelta: {x: 142.49, y: 44.3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7319047644643665697
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2474742385343675158}
+  m_CullTransparentMesh: 0
+--- !u!114 &2746714535140008657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2474742385343675158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2542275, g: 0.2735849, b: 0.260464, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5823267679303912973
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2474742385343675158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d0b652f32a2cc243917e4028fa0f046, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.9339623, g: 0.8590691, b: 0.8590691, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2746714535140008657}
+  m_Template: {fileID: 5953323501105947112}
+  m_CaptionText: {fileID: 2995734384352945215}
+  m_CaptionImage: {fileID: 0}
+  m_ItemText: {fileID: 6986874960828887946}
+  m_ItemImage: {fileID: 0}
+  m_Value: 0
+  m_Options:
+    m_Options:
+    - m_Text: ColorChord
+      m_Image: {fileID: 0}
+    - m_Text: Custom
+      m_Image: {fileID: 0}
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1850939700543825432}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorControllerV0, AudioLink
+        m_MethodName: OnGUIchange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: OnGUIchange
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_AlphaFadeSpeed: 0.15
+--- !u!1 &2581184357028585235
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1108610558939749288}
+  - component: {fileID: 5589654199994658055}
+  - component: {fileID: 3751967358380684254}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1108610558939749288
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2581184357028585235}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 597216306356108682}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5589654199994658055
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2581184357028585235}
+  m_CullTransparentMesh: 0
+--- !u!114 &3751967358380684254
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2581184357028585235}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2588496577874481070
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8747447408919666982}
+  - component: {fileID: 5674724679542436558}
+  - component: {fileID: 7104802423927345421}
+  m_Layer: 5
+  m_Name: Arrows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8747447408919666982
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2588496577874481070}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2707185987352724042}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5674724679542436558
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2588496577874481070}
+  m_CullTransparentMesh: 0
+--- !u!114 &7104802423927345421
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2588496577874481070}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9622642, g: 0.9622642, b: 0.9622642, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 4732271440486325600, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2626969138551655030
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3526953655024287132}
+  - component: {fileID: 2377530643556797269}
+  - component: {fileID: 2995734384352945215}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3526953655024287132
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2626969138551655030}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0000009479975}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 564383905692579421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 9.999985, y: -0.6699996}
+  m_SizeDelta: {x: 57.400017, y: 17.619999}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &2377530643556797269
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2626969138551655030}
+  m_CullTransparentMesh: 0
+--- !u!114 &2995734384352945215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2626969138551655030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8867924, g: 0.8867924, b: 0.8867924, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: ColorChord
+--- !u!1 &2715544242172292646
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2810420970227791832}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2810420970227791832
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2715544242172292646}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1766534858228455527}
+  - {fileID: 3736991720856878419}
+  m_Father: {fileID: 755906456052930412}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2751258122920960353
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6627089211597181214}
+  - component: {fileID: 7321879535990880478}
+  - component: {fileID: 299174434438797867}
+  m_Layer: 5
+  m_Name: Arrows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6627089211597181214
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2751258122920960353}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 597216306356108682}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7321879535990880478
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2751258122920960353}
+  m_CullTransparentMesh: 0
+--- !u!114 &299174434438797867
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2751258122920960353}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9622642, g: 0.9622642, b: 0.9622642, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 4732271440486325600, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2758436512453006918
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2236951152314625967}
+  - component: {fileID: 340250160985076160}
+  - component: {fileID: 4214493551660651321}
+  m_Layer: 5
+  m_Name: Item Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2236951152314625967
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2758436512453006918}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 67298253512936032}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &340250160985076160
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2758436512453006918}
+  m_CullTransparentMesh: 0
+--- !u!114 &4214493551660651321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2758436512453006918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.16078432, g: 0.16078432, b: 0.16078432, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2948345315287277775
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3182769084916397824}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3182769084916397824
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2948345315287277775}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4896683244871404926}
+  m_Father: {fileID: 6211083257301588466}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2961995333703010021
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3938557938234977248}
+  m_Layer: 5
+  m_Name: Theme Color
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3938557938234977248
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2961995333703010021}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2.0876222, y: 2.0876222, z: 2.0876222}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 564383905692579421}
+  - {fileID: 8209493305394938586}
+  - {fileID: 8234031431788457986}
+  - {fileID: 4540085225242892592}
+  - {fileID: 846863225823449409}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -187.2, y: -529.5}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2997917323690629020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3966533101865922583}
+  - component: {fileID: 5909388977654816028}
+  m_Layer: 5
+  m_Name: Slider_Treble
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3966533101865922583
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997917323690629020}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2102039123361795702}
+  - {fileID: 4636070439337054090}
+  - {fileID: 613075870674757949}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -100, y: 115}
+  m_SizeDelta: {x: 155, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5909388977654816028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997917323690629020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 381330681511655096}
+  m_FillRect: {fileID: 1772169438577012145}
+  m_HandleRect: {fileID: 7323276574581615606}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 2
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &3032335892314342646
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5555368900525348513}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5555368900525348513
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3032335892314342646}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5010344552590156317}
+  m_Father: {fileID: 8389301493180030887}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3099574253644011805
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5937276164638600685}
+  - component: {fileID: 4803164192094601243}
+  - component: {fileID: 1349356511375537446}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5937276164638600685
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3099574253644011805}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4191061569453193425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4803164192094601243
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3099574253644011805}
+  m_CullTransparentMesh: 0
+--- !u!114 &1349356511375537446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3099574253644011805}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -8932229983578582238, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3205635017154163392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2102039123361795702}
+  - component: {fileID: 6548766213757705538}
+  - component: {fileID: 8248705911796628949}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2102039123361795702
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3205635017154163392}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3966533101865922583}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6548766213757705538
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3205635017154163392}
+  m_CullTransparentMesh: 0
+--- !u!114 &8248705911796628949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3205635017154163392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -8932229983578582238, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3281979332747532895
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 839313487227615458}
+  - component: {fileID: 570521122837578416}
+  - component: {fileID: 1886681580547739433}
+  m_Layer: 5
+  m_Name: Text_Bass
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &839313487227615458
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3281979332747532895}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.01}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 240, y: 50}
+  m_SizeDelta: {x: 180, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &570521122837578416
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3281979332747532895}
+  m_CullTransparentMesh: 0
+--- !u!114 &1886681580547739433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3281979332747532895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Bass:'
+--- !u!1 &3293721361519897506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5985062561758315514}
+  m_Layer: 5
+  m_Name: ThemeColor HSV choice
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5985062561758315514
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3293721361519897506}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3989778097179809992}
+  - {fileID: 6211083257301588466}
+  - {fileID: 81144368267000887}
+  - {fileID: 3540000653128285123}
+  - {fileID: 5291137704904722980}
+  - {fileID: 7954597745682394460}
+  - {fileID: 8665303574430299364}
+  m_Father: {fileID: 2289852777965071185}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -100.00001, y: -64.60008}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3333038503503331802
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 597216306356108682}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &597216306356108682
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3333038503503331802}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6627089211597181214}
+  - {fileID: 1108610558939749288}
+  m_Father: {fileID: 950702192215621000}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3381404173771369663
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1385507795333360364}
+  - component: {fileID: 72848518332912732}
+  - component: {fileID: 2927739021831967378}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1385507795333360364
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3381404173771369663}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2707185987352724042}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &72848518332912732
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3381404173771369663}
+  m_CullTransparentMesh: 0
+--- !u!114 &2927739021831967378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3381404173771369663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3393282881584667690
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2289852777965071185}
+  - component: {fileID: 4569020541045966322}
+  - component: {fileID: 6261335996076213316}
+  - component: {fileID: 7293248854080350192}
+  m_Layer: 5
+  m_Name: HSV Extension Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2289852777965071185
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3393282881584667690}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0002500005}
+  m_LocalScale: {x: 0.00025, y: 0.00025, z: 0.00025}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6225072485318872874}
+  - {fileID: 740074316738694871}
+  - {fileID: 6701781635586182092}
+  - {fileID: 1790510341792623638}
+  - {fileID: 5985062561758315514}
+  m_Father: {fileID: 4131549791695146592}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.1651}
+  m_SizeDelta: {x: 720, y: 510.69727}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &4569020541045966322
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3393282881584667690}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &6261335996076213316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3393282881584667690}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &7293248854080350192
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3393282881584667690}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &3488280329436686409
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6899287784725531140}
+  - component: {fileID: 6718341548252737476}
+  - component: {fileID: 5858702394358639374}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6899287784725531140
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3488280329436686409}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5818042179479905667}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &6718341548252737476
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3488280329436686409}
+  m_CullTransparentMesh: 0
+--- !u!114 &5858702394358639374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3488280329436686409}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.078431375, g: 0.18431373, b: 0.078431375, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3540050131124446516
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4540085225242892592}
+  - component: {fileID: 813744217409864341}
+  - component: {fileID: 6626926733105320727}
+  - component: {fileID: 7264419016974805630}
+  m_Layer: 5
+  m_Name: Custom Color Button 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4540085225242892592
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3540050131124446516}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3938557938234977248}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 98.3, y: -3.8001356}
+  m_SizeDelta: {x: 36, y: 36}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &813744217409864341
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3540050131124446516}
+  m_CullTransparentMesh: 0
+--- !u!114 &6626926733105320727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3540050131124446516}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7264419016974805630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3540050131124446516}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 9054500918927054283}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1850939700543825432}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorControllerV0, AudioLink
+        m_MethodName: SelectCustomColor2
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: SelectCustomColor2
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &3546840563504705876
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7687432004666858861}
+  - component: {fileID: 5127355368597840234}
+  - component: {fileID: 2719746875293942512}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7687432004666858861
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3546840563504705876}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5802662301798343228}
+  m_Father: {fileID: 4713431405967627444}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -15}
+  m_SizeDelta: {x: 0, y: -30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5127355368597840234
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3546840563504705876}
+  m_CullTransparentMesh: 0
+--- !u!114 &2719746875293942512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3546840563504705876}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3863432772234476843
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7996862113242930854}
+  - component: {fileID: 5874853929795508667}
+  - component: {fileID: 7095705286721444442}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7996862113242930854
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3863432772234476843}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6211083257301588466}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5874853929795508667
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3863432772234476843}
+  m_CullTransparentMesh: 0
+--- !u!114 &7095705286721444442
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3863432772234476843}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: cc21a6e0cd0860d4f82a5c372af7090e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3900953403204262095
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1766534858228455527}
+  - component: {fileID: 3876996700427873443}
+  - component: {fileID: 3722549511522459516}
+  m_Layer: 5
+  m_Name: Arrows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1766534858228455527
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3900953403204262095}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2810420970227791832}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3876996700427873443
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3900953403204262095}
+  m_CullTransparentMesh: 0
+--- !u!114 &3722549511522459516
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3900953403204262095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9622642, g: 0.9622642, b: 0.9622642, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 4732271440486325600, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4008204797625601309
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 495592281116711394}
+  - component: {fileID: 8826098116779894350}
+  - component: {fileID: 8691744370160237964}
+  - component: {fileID: 3733235706951746745}
+  m_Layer: 5
+  m_Name: Viewport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &495592281116711394
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008204797625601309}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6695695180628387938}
+  m_Father: {fileID: 5953323501105947112}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &8826098116779894350
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008204797625601309}
+  m_CullTransparentMesh: 0
+--- !u!114 &8691744370160237964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008204797625601309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3733235706951746745
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008204797625601309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
+--- !u!1 &4135393661838202721
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6777569332825272718}
+  - component: {fileID: 869472372565450232}
+  - component: {fileID: 935200563596988965}
+  - component: {fileID: 2418080210105589431}
+  m_Layer: 5
+  m_Name: Scrollbar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6777569332825272718
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4135393661838202721}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1441439271432301104}
+  m_Father: {fileID: 5953323501105947112}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &869472372565450232
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4135393661838202721}
+  m_CullTransparentMesh: 0
+--- !u!114 &935200563596988965
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4135393661838202721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.20754719, g: 0.20754719, b: 0.20754719, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2418080210105589431
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4135393661838202721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4699093125148747578}
+  m_HandleRect: {fileID: 6329570556181070466}
+  m_Direction: 2
+  m_Value: 1
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &4148066762752447866
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8376191888004989568}
+  - component: {fileID: 1801571568554454164}
+  - component: {fileID: 6929677542786725957}
+  m_Layer: 5
+  m_Name: Arrow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8376191888004989568
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4148066762752447866}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 564383905692579421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -15, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1801571568554454164
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4148066762752447866}
+  m_CullTransparentMesh: 0
+--- !u!114 &6929677542786725957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4148066762752447866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 68b2dbf33f8663c42ae779f13903a48c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4148636520464599982
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9075970846054324954}
+  - component: {fileID: 8085604536808058863}
+  - component: {fileID: 9010347870958215831}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9075970846054324954
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4148636520464599982}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 81144368267000887}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8085604536808058863
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4148636520464599982}
+  m_CullTransparentMesh: 0
+--- !u!114 &9010347870958215831
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4148636520464599982}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -8932229983578582238, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4178147081364712718
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3353378655135826526}
+  - component: {fileID: 6320424093222405020}
+  - component: {fileID: 2917412958333923715}
+  m_Layer: 5
+  m_Name: Arrows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3353378655135826526
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4178147081364712718}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 45675564460246822}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6320424093222405020
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4178147081364712718}
+  m_CullTransparentMesh: 0
+--- !u!114 &2917412958333923715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4178147081364712718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9622642, g: 0.9622642, b: 0.9622642, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 4732271440486325600, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4244853911163724017
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2055249218080543537}
+  - component: {fileID: 3207144470259940718}
+  - component: {fileID: 8986094163746590516}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2055249218080543537
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4244853911163724017}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3268884577075728527}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3207144470259940718
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4244853911163724017}
+  m_CullTransparentMesh: 0
+--- !u!114 &8986094163746590516
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4244853911163724017}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7411765, g: 0.77081144, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 466899909232642061, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4305429186885028522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1404853390035718390}
+  - component: {fileID: 5676421302646723761}
+  - component: {fileID: 6986874960828887946}
+  m_Layer: 5
+  m_Name: Item Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1404853390035718390
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4305429186885028522}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0000009479975}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 67298253512936032}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 19.999992, y: 0.034996033}
+  m_SizeDelta: {x: 55.80001, y: 17.069998}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &5676421302646723761
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4305429186885028522}
+  m_CullTransparentMesh: 0
+--- !u!114 &6986874960828887946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4305429186885028522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 37
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 50
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: Option A
+--- !u!1 &4325732531270166517
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8295635553947709857}
+  - component: {fileID: 8639382425342172044}
+  - component: {fileID: 3328837548849540611}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8295635553947709857
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4325732531270166517}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6852887461488891925}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &8639382425342172044
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4325732531270166517}
+  m_CullTransparentMesh: 0
+--- !u!114 &3328837548849540611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4325732531270166517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.28, g: 0.20666665, b: 0.006666658, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4499803016043048506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6481320243168476059}
+  - component: {fileID: 6582587184179245700}
+  m_Layer: 5
+  m_Name: Slider_Bass
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6481320243168476059
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4499803016043048506}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7408460948791976823}
+  - {fileID: 3587909936672466149}
+  - {fileID: 6918201764202695895}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -100, y: 50}
+  m_SizeDelta: {x: 155, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6582587184179245700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4499803016043048506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4962319185306550440}
+  m_FillRect: {fileID: 4217977457897167966}
+  m_HandleRect: {fileID: 6607018586872715571}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 2
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &4537014016074450530
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6701781635586182092}
+  - component: {fileID: 6671388009442685162}
+  - component: {fileID: 2082410319425608412}
+  m_Layer: 5
+  m_Name: selection lasso 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6701781635586182092
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4537014016074450530}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3.3394475, y: 3.3394475, z: 3.3394475}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2289852777965071185}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 377.30002, y: 420.40012}
+  m_SizeDelta: {x: 128, y: 128}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &6671388009442685162
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4537014016074450530}
+  m_CullTransparentMesh: 0
+--- !u!114 &2082410319425608412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4537014016074450530}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5da651327a17f2445ac37517e67e1197, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 1
+  m_FillAmount: 0.676
+  m_FillClockwise: 1
+  m_FillOrigin: 1
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4582096666971745500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5366349926897015779}
+  - component: {fileID: 376218946997873044}
+  - component: {fileID: 1709492604893555616}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5366349926897015779
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4582096666971745500}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3377691481059036561}
+  m_Father: {fileID: 8513434883236684275}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -15}
+  m_SizeDelta: {x: 0, y: -30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &376218946997873044
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4582096666971745500}
+  m_CullTransparentMesh: 0
+--- !u!114 &1709492604893555616
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4582096666971745500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4600445800944231456
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1772169438577012145}
+  - component: {fileID: 8286708600093815093}
+  - component: {fileID: 8723756152353090230}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1772169438577012145
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4600445800944231456}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4636070439337054090}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8286708600093815093
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4600445800944231456}
+  m_CullTransparentMesh: 0
+--- !u!114 &8723756152353090230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4600445800944231456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7411765, g: 0.77081144, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 466899909232642061, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4669499453442037505
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8944728106324634797}
+  - component: {fileID: 7394978134946401700}
+  m_Layer: 5
+  m_Name: Slider_X3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8944728106324634797
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4669499453442037505}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4964470217518058889}
+  - {fileID: 755906456052930412}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.704, y: 0.5}
+  m_AnchorMax: {x: 0.953, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 385}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7394978134946401700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4669499453442037505}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 2810420970227791832}
+  m_Direction: 0
+  m_MinValue: 0.704
+  m_MaxValue: 0.953
+  m_WholeNumbers: 0
+  m_Value: 0.75
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &4751962254571475665
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5782120197581889859}
+  - component: {fileID: 1925383117982107298}
+  - component: {fileID: 178277259643701196}
+  m_Layer: 13
+  m_Name: SpectrumUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5782120197581889859
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4751962254571475665}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0000014081597, y: 0.7071068, z: -0.7071068, w: 0.0000014081597}
+  m_LocalPosition: {x: 0.0001, y: 0.1201, z: 0}
+  m_LocalScale: {x: 0.018, y: 0.01, z: 0.006}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4131549791695146592}
+  m_LocalEulerAnglesHint: {x: -270, y: 0, z: 179.99998}
+--- !u!33 &1925383117982107298
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4751962254571475665}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &178277259643701196
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4751962254571475665}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 06e7d5350bc8fa842b4bdea5200a3a2f, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &4797468373938815907
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7034819572417824379}
+  - component: {fileID: 7698995886956594004}
+  - component: {fileID: 4458663589032845040}
+  m_Layer: 13
+  m_Name: PulseWheel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &7034819572417824379
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4797468373938815907}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071059, y: -0, z: -0, w: 0.7071077}
+  m_LocalPosition: {x: -0.06976401, y: -0.12929997, z: 0}
+  m_LocalScale: {x: 0.06822912, y: 0.06822912, z: 0.06822912}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4131549791695146592}
+  m_LocalEulerAnglesHint: {x: -90.00001, y: 0, z: 0}
+--- !u!33 &7698995886956594004
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4797468373938815907}
+  m_Mesh: {fileID: 4300004, guid: fc095f5c568547944b653fb588900b36, type: 3}
+--- !u!23 &4458663589032845040
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4797468373938815907}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 669f24c4250dc1e479b23e90f14b1190, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &4833589851095721481
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 950702192215621000}
+  - component: {fileID: 4009678864873184125}
+  - component: {fileID: 8434303298182793021}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &950702192215621000
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4833589851095721481}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 597216306356108682}
+  m_Father: {fileID: 6852887461488891925}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -25, y: -25}
+  m_SizeDelta: {x: -50, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4009678864873184125
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4833589851095721481}
+  m_CullTransparentMesh: 0
+--- !u!114 &8434303298182793021
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4833589851095721481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4961405780198360298
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8325780414455094582}
+  - component: {fileID: 5075313921747850092}
+  - component: {fileID: 1020356213190282703}
+  m_Layer: 13
+  m_Name: Theme Color Preview
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8325780414455094582
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4961405780198360298}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0000014081597, y: 0.7071068, z: -0.7071068, w: 0.0000014081597}
+  m_LocalPosition: {x: 0.014075, y: -0.12472491, z: 0}
+  m_LocalScale: {x: 0.0038196002, y: 0.0038196002, z: 0.0038196002}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4131549791695146592}
+  m_LocalEulerAnglesHint: {x: -270, y: 0, z: 179.99998}
+--- !u!33 &5075313921747850092
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4961405780198360298}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1020356213190282703
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4961405780198360298}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b0355a1841b541e439d593cb86254e6e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &4978548010005411526
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4191061569453193425}
+  - component: {fileID: 3511889801236120189}
+  m_Layer: 5
+  m_Name: Slider_FadeExpFalloff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4191061569453193425
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4978548010005411526}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5937276164638600685}
+  - {fileID: 6894109339269569084}
+  - {fileID: 6515159447973143729}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -100, y: -165}
+  m_SizeDelta: {x: 155, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3511889801236120189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4978548010005411526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4724594581952281388}
+  m_FillRect: {fileID: 6348151081563346051}
+  m_HandleRect: {fileID: 1238917468356503524}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.75
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &4985204526050174763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6149888898102457830}
+  - component: {fileID: 3934195940710637850}
+  - component: {fileID: 3586655470007268158}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6149888898102457830
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4985204526050174763}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 621664006397135782}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3934195940710637850
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4985204526050174763}
+  m_CullTransparentMesh: 0
+--- !u!114 &3586655470007268158
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4985204526050174763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5036725982653321849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3377691481059036561}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3377691481059036561
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5036725982653321849}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1030976083278715028}
+  - {fileID: 8195301813084454045}
+  m_Father: {fileID: 5366349926897015779}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5059998905546532786
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1600304112735116786}
+  - component: {fileID: 2289672969328763858}
+  - component: {fileID: 706920929245164496}
+  m_Layer: 5
+  m_Name: Arrows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1600304112735116786
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5059998905546532786}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6587541388514291736}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2289672969328763858
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5059998905546532786}
+  m_CullTransparentMesh: 0
+--- !u!114 &706920929245164496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5059998905546532786}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9622642, g: 0.9622642, b: 0.9622642, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 833714978692016410, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5184001345453581804
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8954637390730935489}
+  - component: {fileID: 1396157200561530134}
+  - component: {fileID: 8078320614143970234}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8954637390730935489
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5184001345453581804}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7610088783915916655}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1396157200561530134
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5184001345453581804}
+  m_CullTransparentMesh: 0
+--- !u!114 &8078320614143970234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5184001345453581804}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5216599962941031237
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6852887461488891925}
+  - component: {fileID: 7778827356106990804}
+  m_Layer: 5
+  m_Name: Slider_X1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6852887461488891925
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5216599962941031237}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8295635553947709857}
+  - {fileID: 950702192215621000}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.242, y: 0.5}
+  m_AnchorMax: {x: 0.461, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 385}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7778827356106990804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5216599962941031237}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 597216306356108682}
+  m_Direction: 0
+  m_MinValue: 0.242
+  m_MaxValue: 0.387
+  m_WholeNumbers: 0
+  m_Value: 0.25
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &5221551501516412222
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6665365187150620791}
+  - component: {fileID: 5422032811525468321}
+  - component: {fileID: 3905708495548794383}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6665365187150620791
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5221551501516412222}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3626197743113610512}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5422032811525468321
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5221551501516412222}
+  m_CullTransparentMesh: 0
+--- !u!114 &3905708495548794383
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5221551501516412222}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7411765, g: 0.77081144, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 466899909232642061, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5255429701413845202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2647878040377071021}
+  - component: {fileID: 5021503393413291892}
+  - component: {fileID: 8001657825349926868}
+  m_Layer: 5
+  m_Name: Text_EQ
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2647878040377071021
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5255429701413845202}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.01}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 170}
+  m_SizeDelta: {x: 660, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5021503393413291892
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5255429701413845202}
+  m_CullTransparentMesh: 0
+--- !u!114 &8001657825349926868
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5255429701413845202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Basic EQ
+--- !u!1 &5404370065642508584
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7408460948791976823}
+  - component: {fileID: 8916185019731034183}
+  - component: {fileID: 8327849296844730638}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7408460948791976823
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5404370065642508584}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6481320243168476059}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8916185019731034183
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5404370065642508584}
+  m_CullTransparentMesh: 0
+--- !u!114 &8327849296844730638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5404370065642508584}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -8932229983578582238, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5443873352993852623
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6865825818680695598}
+  - component: {fileID: 4298667248364110617}
+  - component: {fileID: 6308825743710478370}
+  m_Layer: 5
+  m_Name: Text_FadeExpFalloff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6865825818680695598
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5443873352993852623}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.01}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 240, y: -165}
+  m_SizeDelta: {x: 180, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4298667248364110617
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5443873352993852623}
+  m_CullTransparentMesh: 0
+--- !u!114 &6308825743710478370
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5443873352993852623}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Exp Falloff
+--- !u!1 &5456622785948021567
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5620743313176364246}
+  - component: {fileID: 7941946125918355742}
+  - component: {fileID: 1534764531647648638}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5620743313176364246
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5456622785948021567}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 45675564460246822}
+  m_Father: {fileID: 5818042179479905667}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -25, y: -25}
+  m_SizeDelta: {x: -50, y: 0}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &7941946125918355742
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5456622785948021567}
+  m_CullTransparentMesh: 0
+--- !u!114 &1534764531647648638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5456622785948021567}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5486263440117711411
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3002984106441236886}
+  - component: {fileID: 3934295681557028265}
+  - component: {fileID: 1161565542456588400}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3002984106441236886
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5486263440117711411}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6587541388514291736}
+  m_Father: {fileID: 6863291016076773184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -25, y: -25}
+  m_SizeDelta: {x: -50, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3934295681557028265
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5486263440117711411}
+  m_CullTransparentMesh: 0
+--- !u!114 &1161565542456588400
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5486263440117711411}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5537500591466472408
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8507857730353569049}
+  - component: {fileID: 8984197426162281115}
+  m_Layer: 5
+  m_Name: Slider_Threshold0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8507857730353569049
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5537500591466472408}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3772510671314417429}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0.25, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 190}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &8984197426162281115
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5537500591466472408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 2707185987352724042}
+  m_Direction: 2
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.45
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &5556052403388549315
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7610088783915916655}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7610088783915916655
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5556052403388549315}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8954637390730935489}
+  m_Father: {fileID: 7048797104976552735}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5587526398531164434
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8813662891045527545}
+  - component: {fileID: 4959266237013836319}
+  - component: {fileID: 8806995944205370575}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8813662891045527545
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5587526398531164434}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6204884200885960896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4959266237013836319
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5587526398531164434}
+  m_CullTransparentMesh: 0
+--- !u!114 &8806995944205370575
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5587526398531164434}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7411765, g: 0.77081144, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 466899909232642061, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5956920969381187543
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4131549791695146592}
+  m_Layer: 13
+  m_Name: Screen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4131549791695146592
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5956920969381187543}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.15, y: 0, z: -0.0205}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7034819572417824379}
+  - {fileID: 7292063825441848802}
+  - {fileID: 6078325756396926877}
+  - {fileID: 5782120197581889859}
+  - {fileID: 8325780414455094582}
+  - {fileID: 228587697852268883}
+  - {fileID: 5164404523412461380}
+  - {fileID: 2289852777965071185}
+  m_Father: {fileID: 2343012201522968185}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6153927030067737817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1930787398938376492}
+  - component: {fileID: 3940360945768458519}
+  - component: {fileID: 9048763390749061147}
+  m_Layer: 5
+  m_Name: Text_FadeLength
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1930787398938376492
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6153927030067737817}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.01}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 240, y: -100}
+  m_SizeDelta: {x: 180, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3940360945768458519
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6153927030067737817}
+  m_CullTransparentMesh: 0
+--- !u!114 &9048763390749061147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6153927030067737817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Length
+--- !u!1 &6225275740073611232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6918201764202695895}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6918201764202695895
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6225275740073611232}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6607018586872715571}
+  m_Father: {fileID: 6481320243168476059}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &6425747198454327913
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5040020457055172861}
+  - component: {fileID: 3770280404131383628}
+  - component: {fileID: 8581758448270604185}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5040020457055172861
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6425747198454327913}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.01}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 715667999396053016}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3770280404131383628
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6425747198454327913}
+  m_CullTransparentMesh: 0
+--- !u!114 &8581758448270604185
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6425747198454327913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Reset
+--- !u!1 &6457496421470082540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4896683244871404926}
+  - component: {fileID: 1735488744913304778}
+  - component: {fileID: 8013655815675004964}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4896683244871404926
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6457496421470082540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3182769084916397824}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.75, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1735488744913304778
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6457496421470082540}
+  m_CullTransparentMesh: 0
+--- !u!114 &8013655815675004964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6457496421470082540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6497742788745774820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5010344552590156317}
+  - component: {fileID: 2671899386946008950}
+  - component: {fileID: 973333032987545947}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5010344552590156317
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6497742788745774820}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5555368900525348513}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2671899386946008950
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6497742788745774820}
+  m_CullTransparentMesh: 0
+--- !u!114 &973333032987545947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6497742788745774820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7411765, g: 0.77081144, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 466899909232642061, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6560432073235833852
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4713431405967627444}
+  - component: {fileID: 1217531418047678844}
+  m_Layer: 5
+  m_Name: Slider_Threshold2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4713431405967627444
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6560432073235833852}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7687432004666858861}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 190}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &1217531418047678844
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6560432073235833852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 5802662301798343228}
+  m_Direction: 2
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.45
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &6588589112830614300
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5818042179479905667}
+  - component: {fileID: 6168371980679469750}
+  m_Layer: 5
+  m_Name: Slider_X2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5818042179479905667
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6588589112830614300}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6899287784725531140}
+  - {fileID: 5620743313176364246}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.461, y: 0.5}
+  m_AnchorMax: {x: 0.704, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 385}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6168371980679469750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6588589112830614300}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 45675564460246822}
+  m_Direction: 0
+  m_MinValue: 0.461
+  m_MaxValue: 0.628
+  m_WholeNumbers: 0
+  m_Value: 0.5
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &6698037594447721675
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2819072468132020409}
+  - component: {fileID: 4517960326429351179}
+  - component: {fileID: 1384948307802409971}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2819072468132020409
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6698037594447721675}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6587541388514291736}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4517960326429351179
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6698037594447721675}
+  m_CullTransparentMesh: 0
+--- !u!114 &1384948307802409971
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6698037594447721675}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6747571556754356751
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6607018586872715571}
+  - component: {fileID: 5381572757940284337}
+  - component: {fileID: 4962319185306550440}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6607018586872715571
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6747571556754356751}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6918201764202695895}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5381572757940284337
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6747571556754356751}
+  m_CullTransparentMesh: 0
+--- !u!114 &4962319185306550440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6747571556754356751}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6750380099029187656
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8389301493180030887}
+  - component: {fileID: 6553857647686057892}
+  m_Layer: 5
+  m_Name: Slider_FadeLength
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8389301493180030887
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6750380099029187656}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1515052127383152186}
+  - {fileID: 5555368900525348513}
+  - {fileID: 70514554250852176}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -100, y: -100}
+  m_SizeDelta: {x: 155, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6553857647686057892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6750380099029187656}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 163041159584330565}
+  m_FillRect: {fileID: 5010344552590156317}
+  m_HandleRect: {fileID: 6325235192822953274}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.25
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &6867128946754863759
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8665303574430299364}
+  - component: {fileID: 623806048073169899}
+  - component: {fileID: 4767630337974168125}
+  m_Layer: 5
+  m_Name: Text_ThemeValue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8665303574430299364
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6867128946754863759}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0033322333}
+  m_LocalScale: {x: 0.33333328, y: 0.33333328, z: 0.33333328}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5985062561758315514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 113.33333, y: -45.7}
+  m_SizeDelta: {x: 180, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &623806048073169899
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6867128946754863759}
+  m_CullTransparentMesh: 0
+--- !u!114 &4767630337974168125
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6867128946754863759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Value
+
+'
+--- !u!1 &6978744310758371069
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 228587697852268883}
+  - component: {fileID: 8766229496176938631}
+  - component: {fileID: 6933295840244026968}
+  - component: {fileID: 7362101958038881101}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &228587697852268883
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6978744310758371069}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0002500005}
+  m_LocalScale: {x: 0.00025, y: 0.00025, z: 0.00025}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3938557938234977248}
+  - {fileID: 7939337666820477482}
+  - {fileID: 7048797104976552735}
+  - {fileID: 3966533101865922583}
+  - {fileID: 6481320243168476059}
+  - {fileID: 8389301493180030887}
+  - {fileID: 4191061569453193425}
+  - {fileID: 6863291016076773184}
+  - {fileID: 6852887461488891925}
+  - {fileID: 5818042179479905667}
+  - {fileID: 8944728106324634797}
+  - {fileID: 8507857730353569049}
+  - {fileID: 1634500531030701399}
+  - {fileID: 4713431405967627444}
+  - {fileID: 8513434883236684275}
+  - {fileID: 715667999396053016}
+  - {fileID: 7822150350519116539}
+  - {fileID: 2647878040377071021}
+  - {fileID: 8607892683871943599}
+  - {fileID: 839313487227615458}
+  - {fileID: 9022285605094714172}
+  - {fileID: 1930787398938376492}
+  - {fileID: 6865825818680695598}
+  - {fileID: 2523277767201664368}
+  m_Father: {fileID: 4131549791695146592}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 720, y: 1200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &8766229496176938631
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6978744310758371069}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &6933295840244026968
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6978744310758371069}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &7362101958038881101
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6978744310758371069}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &6986968554858085118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1484319440833812737}
+  - component: {fileID: 1850939700543825432}
+  m_Layer: 0
+  m_Name: ThemeColorController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1484319440833812737
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6986968554858085118}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5782097804942190625}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1850939700543825432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6986968554858085118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04c324e7f26747b458f38aeec9327eb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  themeColor1: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  themeColor2: {r: 0, g: 0, b: 1, a: 1}
+  themeColor3: {r: 1, g: 0, b: 0, a: 1}
+  themeColor4: {r: 0, g: 1, b: 0, a: 1}
+  audioLink: {fileID: 0}
+  themeColorDropdown: {fileID: 5823267679303912973}
+  extensionCanvas: {fileID: 2289852777965071185}
+  sliderHue: {fileID: 3659682205379247630}
+  sliderSaturation: {fileID: 4705280400534224718}
+  sliderValue: {fileID: 5160838865076395569}
+  customColorLassos:
+  - {fileID: 6225072485318872874}
+  - {fileID: 740074316738694871}
+  - {fileID: 6701781635586182092}
+  - {fileID: 1790510341792623638}
+  customColorIndex: 0
+--- !u!1 &6987486985849884818
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2666531525135992339}
+  - component: {fileID: 8544328632034850846}
+  - component: {fileID: 5940161003679746229}
+  m_Layer: 13
+  m_Name: BottomCap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2666531525135992339
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6987486985849884818}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.016, y: -0.15, z: 0}
+  m_LocalScale: {x: 0.068, y: 0.02, z: 0.032}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2343012201522968185}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8544328632034850846
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6987486985849884818}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5940161003679746229
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6987486985849884818}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9d42585cf36563f44bb23a67ab21c519, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &7026687685614210226
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1238917468356503524}
+  - component: {fileID: 7561403304708358541}
+  - component: {fileID: 4724594581952281388}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1238917468356503524
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7026687685614210226}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6515159447973143729}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7561403304708358541
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7026687685614210226}
+  m_CullTransparentMesh: 0
+--- !u!114 &4724594581952281388
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7026687685614210226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7186444568741071121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8547719403071840499}
+  - component: {fileID: 6577063848058402433}
+  - component: {fileID: 1318551491897363738}
+  m_Layer: 13
+  m_Name: Cylinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8547719403071840499
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7186444568741071121}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.03, y: 0.14, z: 0.03}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8856027461238760108}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6577063848058402433
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7186444568741071121}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1318551491897363738
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7186444568741071121}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: df851503139d41a458ba0fe2ad6e693d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &7264617997757945905
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2343012201522968185}
+  - component: {fileID: 1463422849182505467}
+  m_Layer: 13
+  m_Name: ControlBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2343012201522968185
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7264617997757945905}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 617790223303503175}
+  - {fileID: 5048483632568495299}
+  - {fileID: 2666531525135992339}
+  - {fileID: 5381398319594870914}
+  - {fileID: 4131549791695146592}
+  m_Father: {fileID: 5782097804942190625}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1773428102 &1463422849182505467
+ParentConstraint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7264617997757945905}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Weight: 1
+  m_TranslationAtRest: {x: 0, y: 0, z: 0}
+  m_RotationAtRest: {x: 0, y: 0, z: 0}
+  m_TranslationOffsets:
+  - {x: 0, y: 0, z: 0}
+  m_RotationOffsets:
+  - {x: 0, y: 0, z: 0}
+  m_AffectTranslationX: 1
+  m_AffectTranslationY: 1
+  m_AffectTranslationZ: 1
+  m_AffectRotationX: 1
+  m_AffectRotationY: 1
+  m_AffectRotationZ: 1
+  m_Active: 1
+  m_IsLocked: 1
+  m_Sources:
+  - sourceTransform: {fileID: 8856027461238760108}
+    weight: 1
+--- !u!1 &7315268036116274811
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7939337666820477482}
+  - component: {fileID: 7715328466649143363}
+  - component: {fileID: 8910669982491014590}
+  m_Layer: 5
+  m_Name: Panel EQ
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7939337666820477482
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7315268036116274811}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.40008545, y: 107.429825}
+  m_SizeDelta: {x: 0.0000038146973, y: -984.86017}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7715328466649143363
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7315268036116274811}
+  m_CullTransparentMesh: 0
+--- !u!114 &8910669982491014590
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7315268036116274811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1509434, g: 0.1509434, b: 0.1509434, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -8932229983578582238, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7339061861002549085
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6078325756396926877}
+  - component: {fileID: 1944027319549159665}
+  - component: {fileID: 1680903767304880634}
+  m_Layer: 13
+  m_Name: TimeWheel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &6078325756396926877
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7339061861002549085}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071059, y: -0, z: -0, w: 0.7071077}
+  m_LocalPosition: {x: 0.027, y: -0.1293, z: 0}
+  m_LocalScale: {x: 0.06822912, y: 0.06822912, z: 0.06822912}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4131549791695146592}
+  m_LocalEulerAnglesHint: {x: -90.00001, y: 0, z: 0}
+--- !u!33 &1944027319549159665
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7339061861002549085}
+  m_Mesh: {fileID: 4300002, guid: fc095f5c568547944b653fb588900b36, type: 3}
+--- !u!23 &1680903767304880634
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7339061861002549085}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 669f24c4250dc1e479b23e90f14b1190, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &7378052475370262001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1441439271432301104}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1441439271432301104
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7378052475370262001}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6329570556181070466}
+  m_Father: {fileID: 6777569332825272718}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7480937486602330165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7535120143339399366}
+  - component: {fileID: 1266038168302993742}
+  - component: {fileID: 7304242593910984965}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7535120143339399366
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7480937486602330165}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8410462824285581589}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.75, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1266038168302993742
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7480937486602330165}
+  m_CullTransparentMesh: 0
+--- !u!114 &7304242593910984965
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7480937486602330165}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7593838505414649491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8209493305394938586}
+  - component: {fileID: 2504660387995940207}
+  - component: {fileID: 6583118888765645795}
+  - component: {fileID: 3405460050540118357}
+  m_Layer: 5
+  m_Name: Custom Color Button 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8209493305394938586
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7593838505414649491}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3938557938234977248}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 98.30002, y: 32.7599}
+  m_SizeDelta: {x: 36, y: 36}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2504660387995940207
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7593838505414649491}
+  m_CullTransparentMesh: 0
+--- !u!114 &6583118888765645795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7593838505414649491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3405460050540118357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7593838505414649491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6583118888765645795}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1850939700543825432}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorControllerV0, AudioLink
+        m_MethodName: SelectCustomColor0
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: SelectCustomColor0
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &7627713066558028450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 617790223303503175}
+  - component: {fileID: 7239673339048727628}
+  - component: {fileID: 4716965305350887240}
+  m_Layer: 13
+  m_Name: Body
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &617790223303503175
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7627713066558028450}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.15, y: 0, z: 0}
+  m_LocalScale: {x: 0.2, y: 0.32000002, z: 0.04}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2343012201522968185}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7239673339048727628
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7627713066558028450}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4716965305350887240
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7627713066558028450}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9d42585cf36563f44bb23a67ab21c519, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &7740851341307532130
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 755906456052930412}
+  - component: {fileID: 3972616795035034280}
+  - component: {fileID: 462991756275403226}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &755906456052930412
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7740851341307532130}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2810420970227791832}
+  m_Father: {fileID: 8944728106324634797}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -25}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3972616795035034280
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7740851341307532130}
+  m_CullTransparentMesh: 0
+--- !u!114 &462991756275403226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7740851341307532130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7830756923824944088
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1030976083278715028}
+  - component: {fileID: 44074600039509157}
+  - component: {fileID: 456056225581092894}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1030976083278715028
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7830756923824944088}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3377691481059036561}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &44074600039509157
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7830756923824944088}
+  m_CullTransparentMesh: 0
+--- !u!114 &456056225581092894
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7830756923824944088}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9622642, g: 0.9622642, b: 0.9622642, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 4732271440486325600, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7849400758987216381
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 67298253512936032}
+  - component: {fileID: 3976826112053059553}
+  m_Layer: 5
+  m_Name: Item
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &67298253512936032
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7849400758987216381}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2236951152314625967}
+  - {fileID: 7687428404237491344}
+  - {fileID: 1404853390035718390}
+  m_Father: {fileID: 6695695180628387938}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3976826112053059553
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7849400758987216381}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4214493551660651321}
+  toggleTransition: 1
+  graphic: {fileID: 2823683835280610133}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_IsOn: 1
+--- !u!1 &7866374870634509270
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7292063825441848802}
+  - component: {fileID: 3471675124292681713}
+  - component: {fileID: 5633577306008819836}
+  m_Layer: 13
+  m_Name: SingleWheel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &7292063825441848802
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7866374870634509270}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071059, y: -0, z: -0, w: 0.7071077}
+  m_LocalPosition: {x: -0.02151001, y: -0.12929997, z: 0}
+  m_LocalScale: {x: 0.06822912, y: 0.06822912, z: 0.06822912}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4131549791695146592}
+  m_LocalEulerAnglesHint: {x: -90.00001, y: 0, z: 0}
+--- !u!33 &3471675124292681713
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7866374870634509270}
+  m_Mesh: {fileID: 4300000, guid: fc095f5c568547944b653fb588900b36, type: 3}
+--- !u!23 &5633577306008819836
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7866374870634509270}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 669f24c4250dc1e479b23e90f14b1190, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8001080786024253461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8195301813084454045}
+  - component: {fileID: 4020931256594738208}
+  - component: {fileID: 2518309785063563839}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8195301813084454045
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8001080786024253461}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3377691481059036561}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4020931256594738208
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8001080786024253461}
+  m_CullTransparentMesh: 0
+--- !u!114 &2518309785063563839
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8001080786024253461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8018513744016426112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 621664006397135782}
+  - component: {fileID: 7655942240985943268}
+  - component: {fileID: 3606278627756933394}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &621664006397135782
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8018513744016426112}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7254425578172705206}
+  - {fileID: 6149888898102457830}
+  m_Father: {fileID: 7042605565267472885}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7655942240985943268
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8018513744016426112}
+  m_CullTransparentMesh: 0
+--- !u!114 &3606278627756933394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8018513744016426112}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8085933140775103607
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1634500531030701399}
+  - component: {fileID: 8732576365359434346}
+  m_Layer: 5
+  m_Name: Slider_Threshold1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1634500531030701399
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8085933140775103607}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7042605565267472885}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 190}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &8732576365359434346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8085933140775103607}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 0}
+  m_HandleRect: {fileID: 621664006397135782}
+  m_Direction: 2
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.45
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: UpdateSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: UpdateSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8337429993210727197
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 715667999396053016}
+  - component: {fileID: 2809632519748664709}
+  - component: {fileID: 8939857970247947247}
+  - component: {fileID: 3109837351204790637}
+  m_Layer: 5
+  m_Name: ResetButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &715667999396053016
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8337429993210727197}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5040020457055172861}
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 291, y: -537.5}
+  m_SizeDelta: {x: 140, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2809632519748664709
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8337429993210727197}
+  m_CullTransparentMesh: 0
+--- !u!114 &8939857970247947247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8337429993210727197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 466899909232642061, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3109837351204790637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8337429993210727197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8939857970247947247}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6314710452990588197}
+        m_TargetAssemblyTypeName: AudioLink.AudioLinkControllerV0, AudioLink
+        m_MethodName: ResetSettings
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: ResetSettings
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8400201597141787609
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5092489562077111716}
+  - component: {fileID: 7030245469663970305}
+  - component: {fileID: 1789940870521512839}
+  m_Layer: 5
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5092489562077111716
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8400201597141787609}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5802662301798343228}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7030245469663970305
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8400201597141787609}
+  m_CullTransparentMesh: 0
+--- !u!114 &1789940870521512839
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8400201597141787609}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4992758961664654978, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8462355649591100041
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3636436981537861998}
+  - component: {fileID: 8336953495191399037}
+  - component: {fileID: 7991761288211222334}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3636436981537861998
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8462355649591100041}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6863291016076773184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &8336953495191399037
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8462355649591100041}
+  m_CullTransparentMesh: 0
+--- !u!114 &7991761288211222334
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8462355649591100041}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.20784315, g: 0.039215688, b: 0.039215688, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 890987463210220675, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8493128673602010934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1790510341792623638}
+  - component: {fileID: 4742036593037253864}
+  - component: {fileID: 9094578322465811392}
+  m_Layer: 5
+  m_Name: selection lasso 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1790510341792623638
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8493128673602010934}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3.3394475, y: 3.3394475, z: 3.3394475}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2289852777965071185}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 456.8, y: 420.4003}
+  m_SizeDelta: {x: 128, y: 128}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &4742036593037253864
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8493128673602010934}
+  m_CullTransparentMesh: 0
+--- !u!114 &9094578322465811392
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8493128673602010934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5da651327a17f2445ac37517e67e1197, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 1
+  m_FillAmount: 0.676
+  m_FillClockwise: 1
+  m_FillOrigin: 1
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8553240927687082680
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6225072485318872874}
+  - component: {fileID: 7177348762584274085}
+  - component: {fileID: 6338228680016787628}
+  m_Layer: 5
+  m_Name: selection lasso 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6225072485318872874
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8553240927687082680}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3.3394475, y: 3.3394475, z: 3.3394475}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2289852777965071185}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 377.3, y: 498.4}
+  m_SizeDelta: {x: 128, y: 128}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &7177348762584274085
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8553240927687082680}
+  m_CullTransparentMesh: 0
+--- !u!114 &6338228680016787628
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8553240927687082680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5da651327a17f2445ac37517e67e1197, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 0.324
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8680059774558992738
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7954597745682394460}
+  - component: {fileID: 8360153877110372771}
+  - component: {fileID: 984583362444874494}
+  m_Layer: 5
+  m_Name: Text_ThemeSaturation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7954597745682394460
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8680059774558992738}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0033322333}
+  m_LocalScale: {x: 0.33333328, y: 0.33333328, z: 0.33333328}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5985062561758315514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 113.33333, y: -21.7}
+  m_SizeDelta: {x: 180, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8360153877110372771
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8680059774558992738}
+  m_CullTransparentMesh: 0
+--- !u!114 &984583362444874494
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8680059774558992738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Saturation
+
+'
+--- !u!1 &8731334845614964778
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6515159447973143729}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6515159447973143729
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8731334845614964778}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1238917468356503524}
+  m_Father: {fileID: 4191061569453193425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8736916097257838957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 613075870674757949}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &613075870674757949
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8736916097257838957}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7323276574581615606}
+  m_Father: {fileID: 3966533101865922583}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8785396865838147680
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3268884577075728527}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3268884577075728527
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8785396865838147680}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2055249218080543537}
+  m_Father: {fileID: 6211083257301588466}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8902374451883921114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6211083257301588466}
+  - component: {fileID: 3659682205379247630}
+  m_Layer: 5
+  m_Name: Slider_ThemeHue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6211083257301588466
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8902374451883921114}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7996862113242930854}
+  - {fileID: 3268884577075728527}
+  - {fileID: 3182769084916397824}
+  m_Father: {fileID: 5985062561758315514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.000061035156}
+  m_SizeDelta: {x: 155, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3659682205379247630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8902374451883921114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8013655815675004964}
+  m_FillRect: {fileID: 2055249218080543537}
+  m_HandleRect: {fileID: 4896683244871404926}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.75
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1850939700543825432}
+        m_TargetAssemblyTypeName: AudioLink.ThemeColorControllerV0, AudioLink
+        m_MethodName: OnGUIchange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: OnGUIchange
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8941003738160961934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8607892683871943599}
+  - component: {fileID: 5479924275415789694}
+  - component: {fileID: 7250219814411528253}
+  m_Layer: 5
+  m_Name: Text_Treble
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8607892683871943599
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8941003738160961934}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.01}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 228587697852268883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 240, y: 115}
+  m_SizeDelta: {x: 180, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5479924275415789694
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8941003738160961934}
+  m_CullTransparentMesh: 0
+--- !u!114 &7250219814411528253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8941003738160961934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 66
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Treble:'
+--- !u!1 &8992321203975509209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4217977457897167966}
+  - component: {fileID: 6151344236477868563}
+  - component: {fileID: 1923084373242177064}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4217977457897167966
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8992321203975509209}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3587909936672466149}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6151344236477868563
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8992321203975509209}
+  m_CullTransparentMesh: 0
+--- !u!114 &1923084373242177064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8992321203975509209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7411765, g: 0.77081144, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 466899909232642061, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &9098076877896494459
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1272647278093530404}
+  - component: {fileID: 1111872422471369328}
+  - component: {fileID: 1425394107385662443}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1272647278093530404
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9098076877896494459}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7048797104976552735}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1111872422471369328
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9098076877896494459}
+  m_CullTransparentMesh: 0
+--- !u!114 &1425394107385662443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9098076877896494459}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -8932229983578582238, guid: cd29a871b9a3a1b4fa307fdcc68de817, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Packages/com.llealloo.audiolink/Runtime/Standalone/AudioLinkControllerV0-Standalone.prefab.meta
+++ b/Packages/com.llealloo.audiolink/Runtime/Standalone/AudioLinkControllerV0-Standalone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e7c04a1fd89adb349a94ca034e2dc6de
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This does NOT touch any of the core CRT shaders. This is all the material shaders for meshes (demos/controller internals/etc). Additionally this does NOT modify contents of any Amplify-based shaders, since it involves a third-party system.

- Add URP supporting passes (DepthOnly/DepthNormals) to most shaders, except the amlify ones.
- Add or convert to fragment-based subshader for surf shaders for URP support, since URP doesn't support surf. 
- Add combined (BIRP)Standard/(URP)Lit shader and inspector that handles both depending on the pipeline.
- Add combined (BIRP)Unlit/(URP)Unlit shader that handles both pipelines. 
- Update controller materials to use the new StandardLit shader. 
- Add pipeline detector for setting respective shader global as needed (required for StandardLit). 
- Add controller variants for standalone use (non-vrchat), include URP support. 
- Convert AudioLinkAmplify_4Band into a new general fragment shader Internal/AudioLink_4Band, since it's used on the controller, it needs URP support. 
- Move AudioReactiveSurface to the Amplify folder (since they are amplify-based shaders) and make URP compatible non-amplify variant. 
- Move the collection of functions for the AudioLinkUI into a helper include to declutter the shader file. 
- Some whitespace formatting I guess.

There is a bit more in this that I originally anticipated. Please ask any if there are any questions.