### PR TITLE
Add FFmpeg support in Editor

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -535,7 +535,7 @@ namespace AudioLink
 
             if (_ffmpegProc != null)
             {
-                _ffmpegProc.StandardInput.Write("q");
+                _ffmpegProc.StandardInput.Write('q');
                 _ffmpegProc.StandardInput.Flush();
             }
 

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -736,6 +736,9 @@ namespace AudioLink
             float playbackTime = hasVideoPlayer ? _ytdlpPlayer.GetPlaybackTime() : 0;
             double videoLength = hasVideoPlayer ? _ytdlpPlayer.videoPlayer.length : 0;
 
+            if (ytdlpURLResolver.IsFFmpegAvailable())
+                EditorGUILayout.HelpBox("Using FFmpeg to transcode test videos into a compatible format locally.\n\nThis may play videos that *are not* supported in VRChat / CilloutVR,\nhowever it does not support livestreams.", MessageType.Info);
+
             using (new EditorGUI.DisabledScope(!available))
             {
                 using (new EditorGUILayout.HorizontalScope())

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -234,7 +234,6 @@ namespace AudioLink
         private static bool _ytdlpFound = false;
         private static Newtonsoft.Json.Linq.JObject _ytdlpJson;
 
-        //private static bool _useFFmpeg = false;
         private static string _ffmpegPath = "";
         private static bool _ffmpegFound = false;
         private static string _ffmpegCache = "Video Cache";
@@ -454,14 +453,14 @@ namespace AudioLink
             {
                 if (File.Exists(customPath))
                 {
-                    Debug.Log($"[AudioLink:ytdlp] Custom YTDL location found: {customPath}");
+                    Debug.Log($"[AudioLink:YT-dlp] Custom YTDL location found: {customPath}");
                     _ytdlpPath = customPath;
                     _ytdlpFound = true;
                     return;
                 }
 
-                Debug.LogWarning($"[AudioLink:ytdlp] Custom YTDL location detected but does not exist: {customPath}");
-                Debug.Log("[AudioLink:ytdlp] Checking other locations...");
+                Debug.LogWarning($"[AudioLink:YT-dlp] Custom YTDL location detected but does not exist: {customPath}");
+                Debug.Log("[AudioLink:YT-dlp] Checking other locations...");
             }
 
 
@@ -484,7 +483,7 @@ namespace AudioLink
                 return;
 
             _ytdlpFound = true;
-            Debug.Log($"[AudioLink:ytdlp] Found yt-dlp at path '{_ytdlpPath}'");
+            Debug.Log($"[AudioLink:YT-dlp] Found yt-dlp at path '{_ytdlpPath}'");
         }
 
         public static void Resolve(string url, Action<ytdlpRequest> callback, int resolution = 720)
@@ -496,11 +495,14 @@ namespace AudioLink
 
             if (!_ytdlpFound)
             {
-                Debug.LogWarning($"[AudioLink:ytdlp] Unable to resolve URL '{url}' : yt-dlp not found");
+                Debug.LogWarning($"[AudioLink:YT-dlp] Unable to resolve URL '{url}' : yt-dlp not found");
             }
 
-            if (!File.Exists(Path.GetFullPath(_ffmpegCache)))
-                Directory.CreateDirectory(Path.GetFullPath(_ffmpegCache));
+#if !UNITY_EDITOR_LINUX
+            if (IsFFmpegAvailable())
+#endif
+                if (!File.Exists(Path.GetFullPath(_ffmpegCache)))
+                    Directory.CreateDirectory(Path.GetFullPath(_ffmpegCache));
 
             string urlHash = Hash128.Compute(url).ToString();
             string fullUrlHash = Path.GetFullPath(Path.Combine(_ffmpegCache, urlHash + ".webm"));
@@ -564,7 +566,8 @@ namespace AudioLink
                             debugStdout = args.Data.Replace(args.Data.Substring(filterStart + 3, filterEnd), "[REDACTED]");
                         }
 
-                        Debug.Log("[AudioLink:ytdlp] ytdlp stdout: " + debugStdout);
+                        Debug.Log("[AudioLink:YT-dlp] ytdlp resolved: " + debugStdout);
+
 #if UNITY_EDITOR_LINUX
                         bool useFFmpeg = true;
 #else
@@ -590,7 +593,7 @@ namespace AudioLink
             {
                 if (args.Data != null)
                 {
-                    Debug.LogError("[AudioLink:ytdlp] ytdlp stderr: " + args.Data);
+                    Debug.LogError("[AudioLink:YT-dlp] ytdlp stderr: " + args.Data);
                 }
             };
 
@@ -602,7 +605,7 @@ namespace AudioLink
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AudioLink:ytdlp] Unable to resolve URL '{url}' : " + e.Message);
+                Debug.LogWarning($"[AudioLink:YT-dlp] Unable to resolve URL '{url}' : " + e.Message);
                 callback(null);
             }
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -393,7 +393,9 @@ namespace AudioLink
                             transcodeID = $" ({(string)transcodeIDToken})";
                         }
 
-                        Debug.Log($"[AudioLink:FFmpeg] Transcode progress{transcodeID}: " + Mathf.FloorToInt((float)(ffmpegProgress.TotalSeconds / _ffmpegTranscodeDuration) * 100f) + "%");
+                        bool infTime = _ffmpegTranscodeDuration < 1.1 && _ffmpegTranscodeDuration > 0.9;
+
+                        Debug.Log($"[AudioLink:FFmpeg] Transcode progress{transcodeID}: {Mathf.FloorToInt((float)(ffmpegProgress.TotalSeconds / _ffmpegTranscodeDuration) * (infTime ? 1f : 100f))}{(infTime ? "s" : "%")}");
                     }
                 }
             };
@@ -549,6 +551,7 @@ namespace AudioLink
                         Newtonsoft.Json.Linq.JToken duration;
                         if (_ytdlpJson.TryGetValue("duration", out duration))
                             _ffmpegTranscodeDuration = (Double)duration;
+                        else _ffmpegTranscodeDuration = 1.0;
                     }
                     else
                     {
@@ -560,7 +563,7 @@ namespace AudioLink
 
                             debugStdout = args.Data.Replace(args.Data.Substring(filterStart + 3, filterEnd), "[REDACTED]");
                         }
-                        
+
                         Debug.Log("[AudioLink:ytdlp] ytdlp stdout: " + debugStdout);
 #if UNITY_EDITOR_LINUX
                         bool useFFmpeg = true;

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -243,8 +243,6 @@ namespace AudioLink
         private static string _ffmpegPath = "";
         private static bool _ffmpegFound = false;
         private static string _ffmpegCache = "Video Cache";
-        private static Double _ffmpegTranscodeDuration = 1.0;
-        private static string _ffmpegTranscodeID = "";
 
         private const string userDefinedYTDLPathKey = "YTDL-PATH-CUSTOM";
         private const string userDefinedYTDLPathMenu = "Tools/AudioLink/Select Custom YTDL Location";
@@ -454,11 +452,11 @@ namespace AudioLink
 #endif
                     transcode.isDone = true;
 
-                    Debug.Log($"[AudioLink:FFmpeg] Transcode completed sucessfully{_ffmpegTranscodeID}.");
+                    Debug.Log($"[AudioLink:FFmpeg] Transcode completed sucessfully. ({_ytdlpJson.id})");
 
-                    _ffmpegTranscodeID = "";
+                    _ytdlpJson.id = "";
                 }
-                else Debug.LogWarning($"[AudioLink:FFmpeg] Failed to transcode Video{_ffmpegTranscodeID}!");
+                else Debug.LogWarning($"[AudioLink:FFmpeg] Failed to transcode Video! ({_ytdlpJson.id})");
 
                 callback(transcode);
 
@@ -471,7 +469,7 @@ namespace AudioLink
                 if (args.Data != null)
                 {
                     if (args.Data == "Press [q] to stop, [?] for help")
-                        Debug.Log($"[AudioLink:FFmpeg] Starting transcode{_ffmpegTranscodeID}.");
+                        Debug.Log($"[AudioLink:FFmpeg] Starting transcode. ({_ytdlpJson.id})");
                     else if (args.Data.StartsWith("frame="))
                     {
                         string progressTimeString = args.Data;
@@ -481,14 +479,12 @@ namespace AudioLink
                         string progressTime = progressTimeString.Substring(progressTimeIndex, progressTimeLength);
                         TimeSpan ffmpegProgress = TimeSpan.Parse(progressTime);
 
-                        bool infTime = _ffmpegTranscodeDuration < 1.1 && _ffmpegTranscodeDuration > 0.9;
-
                         string progressSeconds = ffmpegProgress.ToString();
                         progressSeconds = progressSeconds.Contains('.') ? progressSeconds.Substring(0, progressSeconds.IndexOf('.')) : progressSeconds;
                         progressSeconds += "s";
-                        string progressPercent = infTime ? "" : $"- {Mathf.FloorToInt((float)(ffmpegProgress.TotalSeconds / _ffmpegTranscodeDuration) * 100f)}%";
+                        string progressPercent = _ytdlpJson.duration == 0.0 ? "" : $"- {Mathf.FloorToInt((float)(ffmpegProgress.TotalSeconds / _ytdlpJson.duration) * 100f)}%";
 
-                        Debug.Log($"[AudioLink:FFmpeg] Transcode progress{_ffmpegTranscodeID}: {progressSeconds} {progressPercent}");
+                        Debug.Log($"[AudioLink:FFmpeg] Transcode progress ({_ytdlpJson.id}): {progressSeconds} {progressPercent}");
                     }
                 }
             };
@@ -588,16 +584,6 @@ namespace AudioLink
                     if (args.Data.StartsWith("{"))
                     {
                         _ytdlpJson = JsonUtility.FromJson<VideoMeta>(args.Data);
-
-                        if (_ytdlpJson != null)
-                        {
-                            if (_ytdlpJson.id != null)
-                                _ffmpegTranscodeID = $" ({_ytdlpJson.id})";
-
-                            if (_ytdlpJson.duration != 0.0)
-                                _ffmpegTranscodeDuration = _ytdlpJson.duration;
-                            else _ffmpegTranscodeDuration = 1.0;
-                        }
                     }
                     else
                     {

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -305,6 +305,49 @@ namespace AudioLink
             return _ffmpegFound;
         }
 
+        public static void Locateytdlp()
+        {
+            _ytdlpFound = false;
+
+            // check for a custom install location
+            string customPath = EditorPrefs.GetString(userDefinedYTDLPathKey, string.Empty);
+            if (!string.IsNullOrEmpty(customPath))
+            {
+                if (File.Exists(customPath))
+                {
+                    Debug.Log($"[AudioLink:YT-dlp] Custom YTDL location found: {customPath}");
+                    _ytdlpPath = customPath;
+                    _ytdlpFound = true;
+                    return;
+                }
+
+                Debug.LogWarning($"[AudioLink:YT-dlp] Custom YTDL location detected but does not exist: {customPath}");
+                Debug.Log("[AudioLink:YT-dlp] Checking other locations...");
+            }
+
+
+#if UNITY_EDITOR_WIN
+            string[] splitPath = Application.persistentDataPath.Split('/', '\\');
+            _ytdlpPath = string.Join("\\", splitPath.Take(splitPath.Length - 2)) + "\\VRChat\\VRChat\\Tools\\yt-dlp.exe";
+            if (!File.Exists(_ytdlpPath))
+                _ytdlpPath = _localytdlpPath;
+#else
+            _ytdlpPath = "/usr/bin/yt-dlp";
+#endif
+
+            if (!File.Exists(_ytdlpPath))
+            {
+                string[] possibleExecutableNames = { "yt-dlp", "ytdlp", "youtube-dlp", "youtubedlp", "yt-dl", "ytdl", "youtube-dl", "youtubedl" };
+                _ytdlpPath = LocateExecutable(possibleExecutableNames);
+            }
+
+            if (!File.Exists(_ytdlpPath))
+                return;
+
+            _ytdlpFound = true;
+            Debug.Log($"[AudioLink:YT-dlp] Found yt-dlp at path '{_ytdlpPath}'");
+        }
+
         public static void LocateFFmpeg()
         {
             _ffmpegFound = false;
@@ -455,49 +498,6 @@ namespace AudioLink
                 Debug.LogWarning($"[AudioLink:FFmpeg] Unable to transcode URL '{url}' : " + e.Message);
                 callback(null);
             }
-        }
-
-        public static void Locateytdlp()
-        {
-            _ytdlpFound = false;
-
-            // check for a custom install location
-            string customPath = EditorPrefs.GetString(userDefinedYTDLPathKey, string.Empty);
-            if (!string.IsNullOrEmpty(customPath))
-            {
-                if (File.Exists(customPath))
-                {
-                    Debug.Log($"[AudioLink:YT-dlp] Custom YTDL location found: {customPath}");
-                    _ytdlpPath = customPath;
-                    _ytdlpFound = true;
-                    return;
-                }
-
-                Debug.LogWarning($"[AudioLink:YT-dlp] Custom YTDL location detected but does not exist: {customPath}");
-                Debug.Log("[AudioLink:YT-dlp] Checking other locations...");
-            }
-
-
-#if UNITY_EDITOR_WIN
-            string[] splitPath = Application.persistentDataPath.Split('/', '\\');
-            _ytdlpPath = string.Join("\\", splitPath.Take(splitPath.Length - 2)) + "\\VRChat\\VRChat\\Tools\\yt-dlp.exe";
-            if (!File.Exists(_ytdlpPath))
-                _ytdlpPath = _localytdlpPath;
-#else
-            _ytdlpPath = "/usr/bin/yt-dlp";
-#endif
-
-            if (!File.Exists(_ytdlpPath))
-            {
-                string[] possibleExecutableNames = { "yt-dlp", "ytdlp", "youtube-dlp", "youtubedlp", "yt-dl", "ytdl", "youtube-dl", "youtubedl" };
-                _ytdlpPath = LocateExecutable(possibleExecutableNames);
-            }
-
-            if (!File.Exists(_ytdlpPath))
-                return;
-
-            _ytdlpFound = true;
-            Debug.Log($"[AudioLink:YT-dlp] Found yt-dlp at path '{_ytdlpPath}'");
         }
 
         private static string SanitizeURL(string url, string identifier, char seperator)

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -759,7 +759,7 @@ namespace AudioLink
             double videoLength = hasVideoPlayer ? _ytdlpPlayer.videoPlayer.length : 0;
 
             if (ytdlpURLResolver.IsFFmpegAvailable())
-                EditorGUILayout.HelpBox("Using FFmpeg to transcode test videos into a compatible format locally.\n\nThis may play videos that *are not* supported in VRChat / CilloutVR,\nadditionally it does not support livestreams.", MessageType.Info);
+                EditorGUILayout.HelpBox("Using FFmpeg to transcode test videos into a compatible format locally.\n\nThis may play videos that *are not* supported in VRChat / CilloutVR,\nadditionally it does not support livestreams.\n\nIf you encounter any issues, specify you're using FFmpeg Transcoding when reporting issues.", MessageType.Info);
 
             using (new EditorGUI.DisabledScope(!available))
             {

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -604,7 +604,7 @@ namespace AudioLink
                             int filterStart = args.Data.IndexOf("ip=");
                             int filterEnd = args.Data.Substring(filterStart).IndexOf("&");
 
-                            debugStdout = args.Data.Replace(args.Data.Substring(filterStart + 3, filterEnd), "[REDACTED]");
+                            debugStdout = args.Data.Replace(args.Data.Substring(filterStart + 3, filterEnd - 3), "[REDACTED]");
                         }
 
                         Debug.Log("[AudioLink:YT-dlp] ytdlp resolved: " + debugStdout);

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -424,14 +424,18 @@ namespace AudioLink
 
             resolvingRequest transcode = new resolvingRequest();
 
-            string[] ffmpegArgs = new string[10] {
+            string[] ffmpegArgs = new string[12] {
                 "-y",
+
+                "-hwaccel vulkan",
 
                 "-i", $"\"{url}\"",
 
                 "-c:a", $"{audioCodec}",
 
                 "-c:v", $"{videoCodec}",
+
+                videoCodec == "vp8" ? "-cpu-used 6 -deadline realtime -qmin 0 -qmax 50 -crf 5 -minrate 1M -maxrate 1M -b:v 1M" : "",
 
                 "-f", $"{container}",
 


### PR DESCRIPTION
Adds support for FFmpeg that allows for testing AudioLink in Editor on Linux where H.264 / aac is unsupported, instead Transcoding to vp8 / vorbis, Requires yt-dlp & ffmpeg to be installed via package manager or standalone x86 binaries.