### PR TITLE
Add audiosource curve support to volume assignment (both falloff and blend)

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -154,7 +154,7 @@ namespace AudioLink
         private bool _ignoreRightChannel = false;
         private CustomRenderTextureUpdateMode initialUpdateMode = CustomRenderTextureUpdateMode.Realtime;
 
-#if UDONSHARP
+#if UDONSHARP || CVR_CCK_EXISTS
         [HideInInspector, SerializeField] private Transform audioTarget = null;
         [HideInInspector, SerializeField] private bool autoDetectAudioTarget = false;
 #else
@@ -384,7 +384,7 @@ namespace AudioLink
                 DisableReadback();
             }
 
-#if !UDONSHARP
+#if !UDONSHARP && !CVR_CCK_EXISTS
             Invoke(nameof(AutoCacheAudioTarget), 1);
 #endif
         }
@@ -642,13 +642,16 @@ namespace AudioLink
         {
 #if UDONSHARP
             return _localPlayer.GetTrackingData(VRCPlayerApi.TrackingDataType.Head).position;
+#elif CVR_CCK_EXISTS
+            // TODO: Update with the actual logic for where the player's head is.
+            return audioSource.transform.position;
 #else
             // if audioTarget is unavailable, use the audioSource position to make the curves use 0 for listening distance
             return audioTarget ? audioTarget.position : audioSource.transform.position;
 #endif
         }
 
-#if !UDONSHARP
+#if !UDONSHARP && !CVR_CCK_EXISTS
         private double _lastAudioTargetCheckTime;
 
         private void AutoCacheAudioTarget()

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -656,7 +656,7 @@ namespace AudioLink
         private void AutoCacheAudioTarget()
         {
             if (!autoDetectAudioTarget) return;
-            if (!audioListenerTarget || !audioListenerTarget.isActiveAndEnabled)
+            if (!audioListenerTarget || !audioListenerTarget.gameObject.activeInHierarchy || !audioListenerTarget.isActiveAndEnabled)
                 CacheAudioTarget();
             Invoke(nameof(AutoCacheAudioTarget), audioTarget ? 10 : 1); // check faster until one is found
         }

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -160,6 +160,7 @@ namespace AudioLink
         [HideInInspector, SerializeField] private bool autoDetectAudioTarget = false;
 #else
         public Transform audioTarget = null;
+        public AudioListener audioListenerTarget = null;
         public bool autoDetectAudioTarget = true;
 #endif
 
@@ -652,7 +653,7 @@ namespace AudioLink
 #endif
         }
 
-#if UDONSHARP && !CVR_CCK_EXISTS
+#if !UDONSHARP && !CVR_CCK_EXISTS
         private void AutoCacheAudioTarget()
         {
             if (!autoDetectAudioTarget) return;

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -156,6 +156,7 @@ namespace AudioLink
 
 #if UDONSHARP || CVR_CCK_EXISTS
         [HideInInspector, SerializeField] private Transform audioTarget = null;
+        [HideInInspector, SerializeField] private AudioListener audioListenerTarget = null;
         [HideInInspector, SerializeField] private bool autoDetectAudioTarget = false;
 #else
         public Transform audioTarget = null;
@@ -651,13 +652,12 @@ namespace AudioLink
 #endif
         }
 
-#if !UDONSHARP && !CVR_CCK_EXISTS
-        private double _lastAudioTargetCheckTime;
-
+#if UDONSHARP && !CVR_CCK_EXISTS
         private void AutoCacheAudioTarget()
         {
             if (!autoDetectAudioTarget) return;
-            CacheAudioTarget();
+            if (!audioListenerTarget || !audioListenerTarget.isActiveAndEnabled)
+                CacheAudioTarget();
             Invoke(nameof(AutoCacheAudioTarget), audioTarget ? 10 : 1); // check faster until one is found
         }
 
@@ -672,6 +672,7 @@ namespace AudioLink
             foreach (var l in listeners)
             {
                 if (!l.enabled) continue;
+                audioListenerTarget = l;
                 audioTarget = l.transform;
                 break;
             }

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using UnityEngine;
 
 namespace AudioLink
@@ -156,10 +155,10 @@ namespace AudioLink
         private CustomRenderTextureUpdateMode initialUpdateMode = CustomRenderTextureUpdateMode.Realtime;
 
 #if UDONSHARP
-        [HideInInspector, SerializeField] private Transform audioTarget;
+        [HideInInspector, SerializeField] private Transform audioTarget = null;
         [HideInInspector, SerializeField] private bool autoDetectAudioTarget = false;
 #else
-        public Transform audioTarget;
+        public Transform audioTarget = null;
         public bool autoDetectAudioTarget = true;
 #endif
 
@@ -657,17 +656,23 @@ namespace AudioLink
             if (!autoDetectAudioTarget) return;
             CacheAudioTarget();
             Invoke(nameof(AutoCacheAudioTarget), audioTarget ? 10 : 1); // check faster until one is found
-            UnityEngine.Debug.Log($"Audio target found? {audioTarget != null}");
         }
 
         public void CacheAudioTarget()
         {
 #if UNITY_2022_3_OR_NEWER
-            var listener = FindObjectsByType<AudioListener>(FindObjectsInactive.Exclude, FindObjectsSortMode.None).FirstOrDefault(l => l.enabled);
+            var listeners = FindObjectsByType<AudioListener>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
 #else
-            var listener = FindObjectsOfType<AudioListener>(true).FirstOrDefault(l => l.enabled);
+            var listeners = FindObjectsOfType<AudioListener>(true);
 #endif
-            audioTarget = listener != null ? listener.transform : null;
+            audioTarget = null;
+            foreach (var l in listeners)
+            {
+                if (!l.enabled) continue;
+                audioTarget = l.transform;
+                break;
+            }
+
         }
 #endif
 


### PR DESCRIPTION
Audiolink normalizes the DFT by dividing by volume. This includes adjustment to the volume based on the falloff/blend curves.
In standalone, it will search for a valid (active and enabled) AudioListener and assume that is the audioTarget to calculate distance curve value from.
In VRC, it uses the player's head tracking data.

Additionally, some logic was added to make sure that playmode doesn't permanently modify the update mode from what it is set to originally. This is necessary for when a separate CRT wraps the original audiolink CRT (such as what VRSL does).